### PR TITLE
Add ability to keep Html in rich text

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3483,6 +3483,24 @@ module.exports = DotenvModule
 
 /***/ }),
 
+/***/ 5625:
+/***/ ((module) => {
+
+/*!
+ * Determine if an object is a Buffer
+ *
+ * @author   Feross Aboukhadijeh <https://feross.org>
+ * @license  MIT
+ */
+
+module.exports = function isBuffer (obj) {
+  return obj != null && obj.constructor != null &&
+    typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
+}
+
+
+/***/ }),
+
 /***/ 467:
 /***/ ((module, exports, __nccwpck_require__) => {
 
@@ -14342,14 +14360,10570 @@ function heading(tagName) {
   };
 }
 
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/common/unicode.js
+const UNDEFINED_CODE_POINTS = new Set([
+    65534, 65535, 131070, 131071, 196606, 196607, 262142, 262143, 327678, 327679, 393214,
+    393215, 458750, 458751, 524286, 524287, 589822, 589823, 655358, 655359, 720894,
+    720895, 786430, 786431, 851966, 851967, 917502, 917503, 983038, 983039, 1048574,
+    1048575, 1114110, 1114111,
+]);
+const REPLACEMENT_CHARACTER = '\uFFFD';
+var CODE_POINTS;
+(function (CODE_POINTS) {
+    CODE_POINTS[CODE_POINTS["EOF"] = -1] = "EOF";
+    CODE_POINTS[CODE_POINTS["NULL"] = 0] = "NULL";
+    CODE_POINTS[CODE_POINTS["TABULATION"] = 9] = "TABULATION";
+    CODE_POINTS[CODE_POINTS["CARRIAGE_RETURN"] = 13] = "CARRIAGE_RETURN";
+    CODE_POINTS[CODE_POINTS["LINE_FEED"] = 10] = "LINE_FEED";
+    CODE_POINTS[CODE_POINTS["FORM_FEED"] = 12] = "FORM_FEED";
+    CODE_POINTS[CODE_POINTS["SPACE"] = 32] = "SPACE";
+    CODE_POINTS[CODE_POINTS["EXCLAMATION_MARK"] = 33] = "EXCLAMATION_MARK";
+    CODE_POINTS[CODE_POINTS["QUOTATION_MARK"] = 34] = "QUOTATION_MARK";
+    CODE_POINTS[CODE_POINTS["NUMBER_SIGN"] = 35] = "NUMBER_SIGN";
+    CODE_POINTS[CODE_POINTS["AMPERSAND"] = 38] = "AMPERSAND";
+    CODE_POINTS[CODE_POINTS["APOSTROPHE"] = 39] = "APOSTROPHE";
+    CODE_POINTS[CODE_POINTS["HYPHEN_MINUS"] = 45] = "HYPHEN_MINUS";
+    CODE_POINTS[CODE_POINTS["SOLIDUS"] = 47] = "SOLIDUS";
+    CODE_POINTS[CODE_POINTS["DIGIT_0"] = 48] = "DIGIT_0";
+    CODE_POINTS[CODE_POINTS["DIGIT_9"] = 57] = "DIGIT_9";
+    CODE_POINTS[CODE_POINTS["SEMICOLON"] = 59] = "SEMICOLON";
+    CODE_POINTS[CODE_POINTS["LESS_THAN_SIGN"] = 60] = "LESS_THAN_SIGN";
+    CODE_POINTS[CODE_POINTS["EQUALS_SIGN"] = 61] = "EQUALS_SIGN";
+    CODE_POINTS[CODE_POINTS["GREATER_THAN_SIGN"] = 62] = "GREATER_THAN_SIGN";
+    CODE_POINTS[CODE_POINTS["QUESTION_MARK"] = 63] = "QUESTION_MARK";
+    CODE_POINTS[CODE_POINTS["LATIN_CAPITAL_A"] = 65] = "LATIN_CAPITAL_A";
+    CODE_POINTS[CODE_POINTS["LATIN_CAPITAL_F"] = 70] = "LATIN_CAPITAL_F";
+    CODE_POINTS[CODE_POINTS["LATIN_CAPITAL_X"] = 88] = "LATIN_CAPITAL_X";
+    CODE_POINTS[CODE_POINTS["LATIN_CAPITAL_Z"] = 90] = "LATIN_CAPITAL_Z";
+    CODE_POINTS[CODE_POINTS["RIGHT_SQUARE_BRACKET"] = 93] = "RIGHT_SQUARE_BRACKET";
+    CODE_POINTS[CODE_POINTS["GRAVE_ACCENT"] = 96] = "GRAVE_ACCENT";
+    CODE_POINTS[CODE_POINTS["LATIN_SMALL_A"] = 97] = "LATIN_SMALL_A";
+    CODE_POINTS[CODE_POINTS["LATIN_SMALL_F"] = 102] = "LATIN_SMALL_F";
+    CODE_POINTS[CODE_POINTS["LATIN_SMALL_X"] = 120] = "LATIN_SMALL_X";
+    CODE_POINTS[CODE_POINTS["LATIN_SMALL_Z"] = 122] = "LATIN_SMALL_Z";
+    CODE_POINTS[CODE_POINTS["REPLACEMENT_CHARACTER"] = 65533] = "REPLACEMENT_CHARACTER";
+})(CODE_POINTS = CODE_POINTS || (CODE_POINTS = {}));
+const SEQUENCES = {
+    DASH_DASH: '--',
+    CDATA_START: '[CDATA[',
+    DOCTYPE: 'doctype',
+    SCRIPT: 'script',
+    PUBLIC: 'public',
+    SYSTEM: 'system',
+};
+//Surrogates
+function isSurrogate(cp) {
+    return cp >= 55296 && cp <= 57343;
+}
+function isSurrogatePair(cp) {
+    return cp >= 56320 && cp <= 57343;
+}
+function getSurrogatePairCodePoint(cp1, cp2) {
+    return (cp1 - 55296) * 1024 + 9216 + cp2;
+}
+//NOTE: excluding NULL and ASCII whitespace
+function isControlCodePoint(cp) {
+    return ((cp !== 0x20 && cp !== 0x0a && cp !== 0x0d && cp !== 0x09 && cp !== 0x0c && cp >= 0x01 && cp <= 0x1f) ||
+        (cp >= 0x7f && cp <= 0x9f));
+}
+function isUndefinedCodePoint(cp) {
+    return (cp >= 64976 && cp <= 65007) || UNDEFINED_CODE_POINTS.has(cp);
+}
+//# sourceMappingURL=unicode.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/common/error-codes.js
+var ERR;
+(function (ERR) {
+    ERR["controlCharacterInInputStream"] = "control-character-in-input-stream";
+    ERR["noncharacterInInputStream"] = "noncharacter-in-input-stream";
+    ERR["surrogateInInputStream"] = "surrogate-in-input-stream";
+    ERR["nonVoidHtmlElementStartTagWithTrailingSolidus"] = "non-void-html-element-start-tag-with-trailing-solidus";
+    ERR["endTagWithAttributes"] = "end-tag-with-attributes";
+    ERR["endTagWithTrailingSolidus"] = "end-tag-with-trailing-solidus";
+    ERR["unexpectedSolidusInTag"] = "unexpected-solidus-in-tag";
+    ERR["unexpectedNullCharacter"] = "unexpected-null-character";
+    ERR["unexpectedQuestionMarkInsteadOfTagName"] = "unexpected-question-mark-instead-of-tag-name";
+    ERR["invalidFirstCharacterOfTagName"] = "invalid-first-character-of-tag-name";
+    ERR["unexpectedEqualsSignBeforeAttributeName"] = "unexpected-equals-sign-before-attribute-name";
+    ERR["missingEndTagName"] = "missing-end-tag-name";
+    ERR["unexpectedCharacterInAttributeName"] = "unexpected-character-in-attribute-name";
+    ERR["unknownNamedCharacterReference"] = "unknown-named-character-reference";
+    ERR["missingSemicolonAfterCharacterReference"] = "missing-semicolon-after-character-reference";
+    ERR["unexpectedCharacterAfterDoctypeSystemIdentifier"] = "unexpected-character-after-doctype-system-identifier";
+    ERR["unexpectedCharacterInUnquotedAttributeValue"] = "unexpected-character-in-unquoted-attribute-value";
+    ERR["eofBeforeTagName"] = "eof-before-tag-name";
+    ERR["eofInTag"] = "eof-in-tag";
+    ERR["missingAttributeValue"] = "missing-attribute-value";
+    ERR["missingWhitespaceBetweenAttributes"] = "missing-whitespace-between-attributes";
+    ERR["missingWhitespaceAfterDoctypePublicKeyword"] = "missing-whitespace-after-doctype-public-keyword";
+    ERR["missingWhitespaceBetweenDoctypePublicAndSystemIdentifiers"] = "missing-whitespace-between-doctype-public-and-system-identifiers";
+    ERR["missingWhitespaceAfterDoctypeSystemKeyword"] = "missing-whitespace-after-doctype-system-keyword";
+    ERR["missingQuoteBeforeDoctypePublicIdentifier"] = "missing-quote-before-doctype-public-identifier";
+    ERR["missingQuoteBeforeDoctypeSystemIdentifier"] = "missing-quote-before-doctype-system-identifier";
+    ERR["missingDoctypePublicIdentifier"] = "missing-doctype-public-identifier";
+    ERR["missingDoctypeSystemIdentifier"] = "missing-doctype-system-identifier";
+    ERR["abruptDoctypePublicIdentifier"] = "abrupt-doctype-public-identifier";
+    ERR["abruptDoctypeSystemIdentifier"] = "abrupt-doctype-system-identifier";
+    ERR["cdataInHtmlContent"] = "cdata-in-html-content";
+    ERR["incorrectlyOpenedComment"] = "incorrectly-opened-comment";
+    ERR["eofInScriptHtmlCommentLikeText"] = "eof-in-script-html-comment-like-text";
+    ERR["eofInDoctype"] = "eof-in-doctype";
+    ERR["nestedComment"] = "nested-comment";
+    ERR["abruptClosingOfEmptyComment"] = "abrupt-closing-of-empty-comment";
+    ERR["eofInComment"] = "eof-in-comment";
+    ERR["incorrectlyClosedComment"] = "incorrectly-closed-comment";
+    ERR["eofInCdata"] = "eof-in-cdata";
+    ERR["absenceOfDigitsInNumericCharacterReference"] = "absence-of-digits-in-numeric-character-reference";
+    ERR["nullCharacterReference"] = "null-character-reference";
+    ERR["surrogateCharacterReference"] = "surrogate-character-reference";
+    ERR["characterReferenceOutsideUnicodeRange"] = "character-reference-outside-unicode-range";
+    ERR["controlCharacterReference"] = "control-character-reference";
+    ERR["noncharacterCharacterReference"] = "noncharacter-character-reference";
+    ERR["missingWhitespaceBeforeDoctypeName"] = "missing-whitespace-before-doctype-name";
+    ERR["missingDoctypeName"] = "missing-doctype-name";
+    ERR["invalidCharacterSequenceAfterDoctypeName"] = "invalid-character-sequence-after-doctype-name";
+    ERR["duplicateAttribute"] = "duplicate-attribute";
+    ERR["nonConformingDoctype"] = "non-conforming-doctype";
+    ERR["missingDoctype"] = "missing-doctype";
+    ERR["misplacedDoctype"] = "misplaced-doctype";
+    ERR["endTagWithoutMatchingOpenElement"] = "end-tag-without-matching-open-element";
+    ERR["closingOfElementWithOpenChildElements"] = "closing-of-element-with-open-child-elements";
+    ERR["disallowedContentInNoscriptInHead"] = "disallowed-content-in-noscript-in-head";
+    ERR["openElementsLeftAfterEof"] = "open-elements-left-after-eof";
+    ERR["abandonedHeadElementChild"] = "abandoned-head-element-child";
+    ERR["misplacedStartTagForHeadElement"] = "misplaced-start-tag-for-head-element";
+    ERR["nestedNoscriptInHead"] = "nested-noscript-in-head";
+    ERR["eofInElementThatCanContainOnlyText"] = "eof-in-element-that-can-contain-only-text";
+})(ERR = ERR || (ERR = {}));
+//# sourceMappingURL=error-codes.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/tokenizer/preprocessor.js
+
+
+//Const
+const DEFAULT_BUFFER_WATERLINE = 1 << 16;
+//Preprocessor
+//NOTE: HTML input preprocessing
+//(see: http://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#preprocessing-the-input-stream)
+class Preprocessor {
+    constructor(handler) {
+        this.handler = handler;
+        this.html = '';
+        this.pos = -1;
+        // NOTE: Initial `lastGapPos` is -2, to ensure `col` on initialisation is 0
+        this.lastGapPos = -2;
+        this.gapStack = [];
+        this.skipNextNewLine = false;
+        this.lastChunkWritten = false;
+        this.endOfChunkHit = false;
+        this.bufferWaterline = DEFAULT_BUFFER_WATERLINE;
+        this.isEol = false;
+        this.lineStartPos = 0;
+        this.droppedBufferSize = 0;
+        this.line = 1;
+        //NOTE: avoid reporting errors twice on advance/retreat
+        this.lastErrOffset = -1;
+    }
+    /** The column on the current line. If we just saw a gap (eg. a surrogate pair), return the index before. */
+    get col() {
+        return this.pos - this.lineStartPos + Number(this.lastGapPos !== this.pos);
+    }
+    get offset() {
+        return this.droppedBufferSize + this.pos;
+    }
+    getError(code) {
+        const { line, col, offset } = this;
+        return {
+            code,
+            startLine: line,
+            endLine: line,
+            startCol: col,
+            endCol: col,
+            startOffset: offset,
+            endOffset: offset,
+        };
+    }
+    _err(code) {
+        if (this.handler.onParseError && this.lastErrOffset !== this.offset) {
+            this.lastErrOffset = this.offset;
+            this.handler.onParseError(this.getError(code));
+        }
+    }
+    _addGap() {
+        this.gapStack.push(this.lastGapPos);
+        this.lastGapPos = this.pos;
+    }
+    _processSurrogate(cp) {
+        //NOTE: try to peek a surrogate pair
+        if (this.pos !== this.html.length - 1) {
+            const nextCp = this.html.charCodeAt(this.pos + 1);
+            if (isSurrogatePair(nextCp)) {
+                //NOTE: we have a surrogate pair. Peek pair character and recalculate code point.
+                this.pos++;
+                //NOTE: add a gap that should be avoided during retreat
+                this._addGap();
+                return getSurrogatePairCodePoint(cp, nextCp);
+            }
+        }
+        //NOTE: we are at the end of a chunk, therefore we can't infer the surrogate pair yet.
+        else if (!this.lastChunkWritten) {
+            this.endOfChunkHit = true;
+            return CODE_POINTS.EOF;
+        }
+        //NOTE: isolated surrogate
+        this._err(ERR.surrogateInInputStream);
+        return cp;
+    }
+    willDropParsedChunk() {
+        return this.pos > this.bufferWaterline;
+    }
+    dropParsedChunk() {
+        if (this.willDropParsedChunk()) {
+            this.html = this.html.substring(this.pos);
+            this.lineStartPos -= this.pos;
+            this.droppedBufferSize += this.pos;
+            this.pos = 0;
+            this.lastGapPos = -2;
+            this.gapStack.length = 0;
+        }
+    }
+    write(chunk, isLastChunk) {
+        if (this.html.length > 0) {
+            this.html += chunk;
+        }
+        else {
+            this.html = chunk;
+        }
+        this.endOfChunkHit = false;
+        this.lastChunkWritten = isLastChunk;
+    }
+    insertHtmlAtCurrentPos(chunk) {
+        this.html = this.html.substring(0, this.pos + 1) + chunk + this.html.substring(this.pos + 1);
+        this.endOfChunkHit = false;
+    }
+    startsWith(pattern, caseSensitive) {
+        // Check if our buffer has enough characters
+        if (this.pos + pattern.length > this.html.length) {
+            this.endOfChunkHit = !this.lastChunkWritten;
+            return false;
+        }
+        if (caseSensitive) {
+            return this.html.startsWith(pattern, this.pos);
+        }
+        for (let i = 0; i < pattern.length; i++) {
+            const cp = this.html.charCodeAt(this.pos + i) | 0x20;
+            if (cp !== pattern.charCodeAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    peek(offset) {
+        const pos = this.pos + offset;
+        if (pos >= this.html.length) {
+            this.endOfChunkHit = !this.lastChunkWritten;
+            return CODE_POINTS.EOF;
+        }
+        const code = this.html.charCodeAt(pos);
+        return code === CODE_POINTS.CARRIAGE_RETURN ? CODE_POINTS.LINE_FEED : code;
+    }
+    advance() {
+        this.pos++;
+        //NOTE: LF should be in the last column of the line
+        if (this.isEol) {
+            this.isEol = false;
+            this.line++;
+            this.lineStartPos = this.pos;
+        }
+        if (this.pos >= this.html.length) {
+            this.endOfChunkHit = !this.lastChunkWritten;
+            return CODE_POINTS.EOF;
+        }
+        let cp = this.html.charCodeAt(this.pos);
+        //NOTE: all U+000D CARRIAGE RETURN (CR) characters must be converted to U+000A LINE FEED (LF) characters
+        if (cp === CODE_POINTS.CARRIAGE_RETURN) {
+            this.isEol = true;
+            this.skipNextNewLine = true;
+            return CODE_POINTS.LINE_FEED;
+        }
+        //NOTE: any U+000A LINE FEED (LF) characters that immediately follow a U+000D CARRIAGE RETURN (CR) character
+        //must be ignored.
+        if (cp === CODE_POINTS.LINE_FEED) {
+            this.isEol = true;
+            if (this.skipNextNewLine) {
+                // `line` will be bumped again in the recursive call.
+                this.line--;
+                this.skipNextNewLine = false;
+                this._addGap();
+                return this.advance();
+            }
+        }
+        this.skipNextNewLine = false;
+        if (isSurrogate(cp)) {
+            cp = this._processSurrogate(cp);
+        }
+        //OPTIMIZATION: first check if code point is in the common allowed
+        //range (ASCII alphanumeric, whitespaces, big chunk of BMP)
+        //before going into detailed performance cost validation.
+        const isCommonValidRange = this.handler.onParseError === null ||
+            (cp > 0x1f && cp < 0x7f) ||
+            cp === CODE_POINTS.LINE_FEED ||
+            cp === CODE_POINTS.CARRIAGE_RETURN ||
+            (cp > 0x9f && cp < 64976);
+        if (!isCommonValidRange) {
+            this._checkForProblematicCharacters(cp);
+        }
+        return cp;
+    }
+    _checkForProblematicCharacters(cp) {
+        if (isControlCodePoint(cp)) {
+            this._err(ERR.controlCharacterInInputStream);
+        }
+        else if (isUndefinedCodePoint(cp)) {
+            this._err(ERR.noncharacterInInputStream);
+        }
+    }
+    retreat(count) {
+        this.pos -= count;
+        while (this.pos < this.lastGapPos) {
+            this.lastGapPos = this.gapStack.pop();
+            this.pos--;
+        }
+        this.isEol = false;
+    }
+}
+//# sourceMappingURL=preprocessor.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/common/token.js
+var TokenType;
+(function (TokenType) {
+    TokenType[TokenType["CHARACTER"] = 0] = "CHARACTER";
+    TokenType[TokenType["NULL_CHARACTER"] = 1] = "NULL_CHARACTER";
+    TokenType[TokenType["WHITESPACE_CHARACTER"] = 2] = "WHITESPACE_CHARACTER";
+    TokenType[TokenType["START_TAG"] = 3] = "START_TAG";
+    TokenType[TokenType["END_TAG"] = 4] = "END_TAG";
+    TokenType[TokenType["COMMENT"] = 5] = "COMMENT";
+    TokenType[TokenType["DOCTYPE"] = 6] = "DOCTYPE";
+    TokenType[TokenType["EOF"] = 7] = "EOF";
+    TokenType[TokenType["HIBERNATION"] = 8] = "HIBERNATION";
+})(TokenType = TokenType || (TokenType = {}));
+function getTokenAttr(token, attrName) {
+    for (let i = token.attrs.length - 1; i >= 0; i--) {
+        if (token.attrs[i].name === attrName) {
+            return token.attrs[i].value;
+        }
+    }
+    return null;
+}
+//# sourceMappingURL=token.js.map
+;// CONCATENATED MODULE: ./node_modules/entities/lib/esm/generated/decode-data-html.js
+// Generated using scripts/write-decode-map.ts
+/* harmony default export */ const decode_data_html = (new Uint16Array(
+// prettier-ignore
+"\u1d41<\xd5\u0131\u028a\u049d\u057b\u05d0\u0675\u06de\u07a2\u07d6\u080f\u0a4a\u0a91\u0da1\u0e6d\u0f09\u0f26\u10ca\u1228\u12e1\u1415\u149d\u14c3\u14df\u1525\0\0\0\0\0\0\u156b\u16cd\u198d\u1c12\u1ddd\u1f7e\u2060\u21b0\u228d\u23c0\u23fb\u2442\u2824\u2912\u2d08\u2e48\u2fce\u3016\u32ba\u3639\u37ac\u38fe\u3a28\u3a71\u3ae0\u3b2e\u0800EMabcfglmnoprstu\\bfms\x7f\x84\x8b\x90\x95\x98\xa6\xb3\xb9\xc8\xcflig\u803b\xc6\u40c6P\u803b&\u4026cute\u803b\xc1\u40c1reve;\u4102\u0100iyx}rc\u803b\xc2\u40c2;\u4410r;\uc000\ud835\udd04rave\u803b\xc0\u40c0pha;\u4391acr;\u4100d;\u6a53\u0100gp\x9d\xa1on;\u4104f;\uc000\ud835\udd38plyFunction;\u6061ing\u803b\xc5\u40c5\u0100cs\xbe\xc3r;\uc000\ud835\udc9cign;\u6254ilde\u803b\xc3\u40c3ml\u803b\xc4\u40c4\u0400aceforsu\xe5\xfb\xfe\u0117\u011c\u0122\u0127\u012a\u0100cr\xea\xf2kslash;\u6216\u0176\xf6\xf8;\u6ae7ed;\u6306y;\u4411\u0180crt\u0105\u010b\u0114ause;\u6235noullis;\u612ca;\u4392r;\uc000\ud835\udd05pf;\uc000\ud835\udd39eve;\u42d8c\xf2\u0113mpeq;\u624e\u0700HOacdefhilorsu\u014d\u0151\u0156\u0180\u019e\u01a2\u01b5\u01b7\u01ba\u01dc\u0215\u0273\u0278\u027ecy;\u4427PY\u803b\xa9\u40a9\u0180cpy\u015d\u0162\u017aute;\u4106\u0100;i\u0167\u0168\u62d2talDifferentialD;\u6145leys;\u612d\u0200aeio\u0189\u018e\u0194\u0198ron;\u410cdil\u803b\xc7\u40c7rc;\u4108nint;\u6230ot;\u410a\u0100dn\u01a7\u01adilla;\u40b8terDot;\u40b7\xf2\u017fi;\u43a7rcle\u0200DMPT\u01c7\u01cb\u01d1\u01d6ot;\u6299inus;\u6296lus;\u6295imes;\u6297o\u0100cs\u01e2\u01f8kwiseContourIntegral;\u6232eCurly\u0100DQ\u0203\u020foubleQuote;\u601duote;\u6019\u0200lnpu\u021e\u0228\u0247\u0255on\u0100;e\u0225\u0226\u6237;\u6a74\u0180git\u022f\u0236\u023aruent;\u6261nt;\u622fourIntegral;\u622e\u0100fr\u024c\u024e;\u6102oduct;\u6210nterClockwiseContourIntegral;\u6233oss;\u6a2fcr;\uc000\ud835\udc9ep\u0100;C\u0284\u0285\u62d3ap;\u624d\u0580DJSZacefios\u02a0\u02ac\u02b0\u02b4\u02b8\u02cb\u02d7\u02e1\u02e6\u0333\u048d\u0100;o\u0179\u02a5trahd;\u6911cy;\u4402cy;\u4405cy;\u440f\u0180grs\u02bf\u02c4\u02c7ger;\u6021r;\u61a1hv;\u6ae4\u0100ay\u02d0\u02d5ron;\u410e;\u4414l\u0100;t\u02dd\u02de\u6207a;\u4394r;\uc000\ud835\udd07\u0100af\u02eb\u0327\u0100cm\u02f0\u0322ritical\u0200ADGT\u0300\u0306\u0316\u031ccute;\u40b4o\u0174\u030b\u030d;\u42d9bleAcute;\u42ddrave;\u4060ilde;\u42dcond;\u62c4ferentialD;\u6146\u0470\u033d\0\0\0\u0342\u0354\0\u0405f;\uc000\ud835\udd3b\u0180;DE\u0348\u0349\u034d\u40a8ot;\u60dcqual;\u6250ble\u0300CDLRUV\u0363\u0372\u0382\u03cf\u03e2\u03f8ontourIntegra\xec\u0239o\u0274\u0379\0\0\u037b\xbb\u0349nArrow;\u61d3\u0100eo\u0387\u03a4ft\u0180ART\u0390\u0396\u03a1rrow;\u61d0ightArrow;\u61d4e\xe5\u02cang\u0100LR\u03ab\u03c4eft\u0100AR\u03b3\u03b9rrow;\u67f8ightArrow;\u67faightArrow;\u67f9ight\u0100AT\u03d8\u03derrow;\u61d2ee;\u62a8p\u0241\u03e9\0\0\u03efrrow;\u61d1ownArrow;\u61d5erticalBar;\u6225n\u0300ABLRTa\u0412\u042a\u0430\u045e\u047f\u037crrow\u0180;BU\u041d\u041e\u0422\u6193ar;\u6913pArrow;\u61f5reve;\u4311eft\u02d2\u043a\0\u0446\0\u0450ightVector;\u6950eeVector;\u695eector\u0100;B\u0459\u045a\u61bdar;\u6956ight\u01d4\u0467\0\u0471eeVector;\u695fector\u0100;B\u047a\u047b\u61c1ar;\u6957ee\u0100;A\u0486\u0487\u62a4rrow;\u61a7\u0100ct\u0492\u0497r;\uc000\ud835\udc9frok;\u4110\u0800NTacdfglmopqstux\u04bd\u04c0\u04c4\u04cb\u04de\u04e2\u04e7\u04ee\u04f5\u0521\u052f\u0536\u0552\u055d\u0560\u0565G;\u414aH\u803b\xd0\u40d0cute\u803b\xc9\u40c9\u0180aiy\u04d2\u04d7\u04dcron;\u411arc\u803b\xca\u40ca;\u442dot;\u4116r;\uc000\ud835\udd08rave\u803b\xc8\u40c8ement;\u6208\u0100ap\u04fa\u04fecr;\u4112ty\u0253\u0506\0\0\u0512mallSquare;\u65fberySmallSquare;\u65ab\u0100gp\u0526\u052aon;\u4118f;\uc000\ud835\udd3csilon;\u4395u\u0100ai\u053c\u0549l\u0100;T\u0542\u0543\u6a75ilde;\u6242librium;\u61cc\u0100ci\u0557\u055ar;\u6130m;\u6a73a;\u4397ml\u803b\xcb\u40cb\u0100ip\u056a\u056fsts;\u6203onentialE;\u6147\u0280cfios\u0585\u0588\u058d\u05b2\u05ccy;\u4424r;\uc000\ud835\udd09lled\u0253\u0597\0\0\u05a3mallSquare;\u65fcerySmallSquare;\u65aa\u0370\u05ba\0\u05bf\0\0\u05c4f;\uc000\ud835\udd3dAll;\u6200riertrf;\u6131c\xf2\u05cb\u0600JTabcdfgorst\u05e8\u05ec\u05ef\u05fa\u0600\u0612\u0616\u061b\u061d\u0623\u066c\u0672cy;\u4403\u803b>\u403emma\u0100;d\u05f7\u05f8\u4393;\u43dcreve;\u411e\u0180eiy\u0607\u060c\u0610dil;\u4122rc;\u411c;\u4413ot;\u4120r;\uc000\ud835\udd0a;\u62d9pf;\uc000\ud835\udd3eeater\u0300EFGLST\u0635\u0644\u064e\u0656\u065b\u0666qual\u0100;L\u063e\u063f\u6265ess;\u62dbullEqual;\u6267reater;\u6aa2ess;\u6277lantEqual;\u6a7eilde;\u6273cr;\uc000\ud835\udca2;\u626b\u0400Aacfiosu\u0685\u068b\u0696\u069b\u069e\u06aa\u06be\u06caRDcy;\u442a\u0100ct\u0690\u0694ek;\u42c7;\u405eirc;\u4124r;\u610clbertSpace;\u610b\u01f0\u06af\0\u06b2f;\u610dizontalLine;\u6500\u0100ct\u06c3\u06c5\xf2\u06a9rok;\u4126mp\u0144\u06d0\u06d8ownHum\xf0\u012fqual;\u624f\u0700EJOacdfgmnostu\u06fa\u06fe\u0703\u0707\u070e\u071a\u071e\u0721\u0728\u0744\u0778\u078b\u078f\u0795cy;\u4415lig;\u4132cy;\u4401cute\u803b\xcd\u40cd\u0100iy\u0713\u0718rc\u803b\xce\u40ce;\u4418ot;\u4130r;\u6111rave\u803b\xcc\u40cc\u0180;ap\u0720\u072f\u073f\u0100cg\u0734\u0737r;\u412ainaryI;\u6148lie\xf3\u03dd\u01f4\u0749\0\u0762\u0100;e\u074d\u074e\u622c\u0100gr\u0753\u0758ral;\u622bsection;\u62c2isible\u0100CT\u076c\u0772omma;\u6063imes;\u6062\u0180gpt\u077f\u0783\u0788on;\u412ef;\uc000\ud835\udd40a;\u4399cr;\u6110ilde;\u4128\u01eb\u079a\0\u079ecy;\u4406l\u803b\xcf\u40cf\u0280cfosu\u07ac\u07b7\u07bc\u07c2\u07d0\u0100iy\u07b1\u07b5rc;\u4134;\u4419r;\uc000\ud835\udd0dpf;\uc000\ud835\udd41\u01e3\u07c7\0\u07ccr;\uc000\ud835\udca5rcy;\u4408kcy;\u4404\u0380HJacfos\u07e4\u07e8\u07ec\u07f1\u07fd\u0802\u0808cy;\u4425cy;\u440cppa;\u439a\u0100ey\u07f6\u07fbdil;\u4136;\u441ar;\uc000\ud835\udd0epf;\uc000\ud835\udd42cr;\uc000\ud835\udca6\u0580JTaceflmost\u0825\u0829\u082c\u0850\u0863\u09b3\u09b8\u09c7\u09cd\u0a37\u0a47cy;\u4409\u803b<\u403c\u0280cmnpr\u0837\u083c\u0841\u0844\u084dute;\u4139bda;\u439bg;\u67ealacetrf;\u6112r;\u619e\u0180aey\u0857\u085c\u0861ron;\u413ddil;\u413b;\u441b\u0100fs\u0868\u0970t\u0500ACDFRTUVar\u087e\u08a9\u08b1\u08e0\u08e6\u08fc\u092f\u095b\u0390\u096a\u0100nr\u0883\u088fgleBracket;\u67e8row\u0180;BR\u0899\u089a\u089e\u6190ar;\u61e4ightArrow;\u61c6eiling;\u6308o\u01f5\u08b7\0\u08c3bleBracket;\u67e6n\u01d4\u08c8\0\u08d2eeVector;\u6961ector\u0100;B\u08db\u08dc\u61c3ar;\u6959loor;\u630aight\u0100AV\u08ef\u08f5rrow;\u6194ector;\u694e\u0100er\u0901\u0917e\u0180;AV\u0909\u090a\u0910\u62a3rrow;\u61a4ector;\u695aiangle\u0180;BE\u0924\u0925\u0929\u62b2ar;\u69cfqual;\u62b4p\u0180DTV\u0937\u0942\u094cownVector;\u6951eeVector;\u6960ector\u0100;B\u0956\u0957\u61bfar;\u6958ector\u0100;B\u0965\u0966\u61bcar;\u6952ight\xe1\u039cs\u0300EFGLST\u097e\u098b\u0995\u099d\u09a2\u09adqualGreater;\u62daullEqual;\u6266reater;\u6276ess;\u6aa1lantEqual;\u6a7dilde;\u6272r;\uc000\ud835\udd0f\u0100;e\u09bd\u09be\u62d8ftarrow;\u61daidot;\u413f\u0180npw\u09d4\u0a16\u0a1bg\u0200LRlr\u09de\u09f7\u0a02\u0a10eft\u0100AR\u09e6\u09ecrrow;\u67f5ightArrow;\u67f7ightArrow;\u67f6eft\u0100ar\u03b3\u0a0aight\xe1\u03bfight\xe1\u03caf;\uc000\ud835\udd43er\u0100LR\u0a22\u0a2ceftArrow;\u6199ightArrow;\u6198\u0180cht\u0a3e\u0a40\u0a42\xf2\u084c;\u61b0rok;\u4141;\u626a\u0400acefiosu\u0a5a\u0a5d\u0a60\u0a77\u0a7c\u0a85\u0a8b\u0a8ep;\u6905y;\u441c\u0100dl\u0a65\u0a6fiumSpace;\u605flintrf;\u6133r;\uc000\ud835\udd10nusPlus;\u6213pf;\uc000\ud835\udd44c\xf2\u0a76;\u439c\u0480Jacefostu\u0aa3\u0aa7\u0aad\u0ac0\u0b14\u0b19\u0d91\u0d97\u0d9ecy;\u440acute;\u4143\u0180aey\u0ab4\u0ab9\u0aberon;\u4147dil;\u4145;\u441d\u0180gsw\u0ac7\u0af0\u0b0eative\u0180MTV\u0ad3\u0adf\u0ae8ediumSpace;\u600bhi\u0100cn\u0ae6\u0ad8\xeb\u0ad9eryThi\xee\u0ad9ted\u0100GL\u0af8\u0b06reaterGreate\xf2\u0673essLes\xf3\u0a48Line;\u400ar;\uc000\ud835\udd11\u0200Bnpt\u0b22\u0b28\u0b37\u0b3areak;\u6060BreakingSpace;\u40a0f;\u6115\u0680;CDEGHLNPRSTV\u0b55\u0b56\u0b6a\u0b7c\u0ba1\u0beb\u0c04\u0c5e\u0c84\u0ca6\u0cd8\u0d61\u0d85\u6aec\u0100ou\u0b5b\u0b64ngruent;\u6262pCap;\u626doubleVerticalBar;\u6226\u0180lqx\u0b83\u0b8a\u0b9bement;\u6209ual\u0100;T\u0b92\u0b93\u6260ilde;\uc000\u2242\u0338ists;\u6204reater\u0380;EFGLST\u0bb6\u0bb7\u0bbd\u0bc9\u0bd3\u0bd8\u0be5\u626fqual;\u6271ullEqual;\uc000\u2267\u0338reater;\uc000\u226b\u0338ess;\u6279lantEqual;\uc000\u2a7e\u0338ilde;\u6275ump\u0144\u0bf2\u0bfdownHump;\uc000\u224e\u0338qual;\uc000\u224f\u0338e\u0100fs\u0c0a\u0c27tTriangle\u0180;BE\u0c1a\u0c1b\u0c21\u62eaar;\uc000\u29cf\u0338qual;\u62ecs\u0300;EGLST\u0c35\u0c36\u0c3c\u0c44\u0c4b\u0c58\u626equal;\u6270reater;\u6278ess;\uc000\u226a\u0338lantEqual;\uc000\u2a7d\u0338ilde;\u6274ested\u0100GL\u0c68\u0c79reaterGreater;\uc000\u2aa2\u0338essLess;\uc000\u2aa1\u0338recedes\u0180;ES\u0c92\u0c93\u0c9b\u6280qual;\uc000\u2aaf\u0338lantEqual;\u62e0\u0100ei\u0cab\u0cb9verseElement;\u620cghtTriangle\u0180;BE\u0ccb\u0ccc\u0cd2\u62ebar;\uc000\u29d0\u0338qual;\u62ed\u0100qu\u0cdd\u0d0cuareSu\u0100bp\u0ce8\u0cf9set\u0100;E\u0cf0\u0cf3\uc000\u228f\u0338qual;\u62e2erset\u0100;E\u0d03\u0d06\uc000\u2290\u0338qual;\u62e3\u0180bcp\u0d13\u0d24\u0d4eset\u0100;E\u0d1b\u0d1e\uc000\u2282\u20d2qual;\u6288ceeds\u0200;EST\u0d32\u0d33\u0d3b\u0d46\u6281qual;\uc000\u2ab0\u0338lantEqual;\u62e1ilde;\uc000\u227f\u0338erset\u0100;E\u0d58\u0d5b\uc000\u2283\u20d2qual;\u6289ilde\u0200;EFT\u0d6e\u0d6f\u0d75\u0d7f\u6241qual;\u6244ullEqual;\u6247ilde;\u6249erticalBar;\u6224cr;\uc000\ud835\udca9ilde\u803b\xd1\u40d1;\u439d\u0700Eacdfgmoprstuv\u0dbd\u0dc2\u0dc9\u0dd5\u0ddb\u0de0\u0de7\u0dfc\u0e02\u0e20\u0e22\u0e32\u0e3f\u0e44lig;\u4152cute\u803b\xd3\u40d3\u0100iy\u0dce\u0dd3rc\u803b\xd4\u40d4;\u441eblac;\u4150r;\uc000\ud835\udd12rave\u803b\xd2\u40d2\u0180aei\u0dee\u0df2\u0df6cr;\u414cga;\u43a9cron;\u439fpf;\uc000\ud835\udd46enCurly\u0100DQ\u0e0e\u0e1aoubleQuote;\u601cuote;\u6018;\u6a54\u0100cl\u0e27\u0e2cr;\uc000\ud835\udcaaash\u803b\xd8\u40d8i\u016c\u0e37\u0e3cde\u803b\xd5\u40d5es;\u6a37ml\u803b\xd6\u40d6er\u0100BP\u0e4b\u0e60\u0100ar\u0e50\u0e53r;\u603eac\u0100ek\u0e5a\u0e5c;\u63deet;\u63b4arenthesis;\u63dc\u0480acfhilors\u0e7f\u0e87\u0e8a\u0e8f\u0e92\u0e94\u0e9d\u0eb0\u0efcrtialD;\u6202y;\u441fr;\uc000\ud835\udd13i;\u43a6;\u43a0usMinus;\u40b1\u0100ip\u0ea2\u0eadncareplan\xe5\u069df;\u6119\u0200;eio\u0eb9\u0eba\u0ee0\u0ee4\u6abbcedes\u0200;EST\u0ec8\u0ec9\u0ecf\u0eda\u627aqual;\u6aaflantEqual;\u627cilde;\u627eme;\u6033\u0100dp\u0ee9\u0eeeuct;\u620fortion\u0100;a\u0225\u0ef9l;\u621d\u0100ci\u0f01\u0f06r;\uc000\ud835\udcab;\u43a8\u0200Ufos\u0f11\u0f16\u0f1b\u0f1fOT\u803b\"\u4022r;\uc000\ud835\udd14pf;\u611acr;\uc000\ud835\udcac\u0600BEacefhiorsu\u0f3e\u0f43\u0f47\u0f60\u0f73\u0fa7\u0faa\u0fad\u1096\u10a9\u10b4\u10bearr;\u6910G\u803b\xae\u40ae\u0180cnr\u0f4e\u0f53\u0f56ute;\u4154g;\u67ebr\u0100;t\u0f5c\u0f5d\u61a0l;\u6916\u0180aey\u0f67\u0f6c\u0f71ron;\u4158dil;\u4156;\u4420\u0100;v\u0f78\u0f79\u611cerse\u0100EU\u0f82\u0f99\u0100lq\u0f87\u0f8eement;\u620builibrium;\u61cbpEquilibrium;\u696fr\xbb\u0f79o;\u43a1ght\u0400ACDFTUVa\u0fc1\u0feb\u0ff3\u1022\u1028\u105b\u1087\u03d8\u0100nr\u0fc6\u0fd2gleBracket;\u67e9row\u0180;BL\u0fdc\u0fdd\u0fe1\u6192ar;\u61e5eftArrow;\u61c4eiling;\u6309o\u01f5\u0ff9\0\u1005bleBracket;\u67e7n\u01d4\u100a\0\u1014eeVector;\u695dector\u0100;B\u101d\u101e\u61c2ar;\u6955loor;\u630b\u0100er\u102d\u1043e\u0180;AV\u1035\u1036\u103c\u62a2rrow;\u61a6ector;\u695biangle\u0180;BE\u1050\u1051\u1055\u62b3ar;\u69d0qual;\u62b5p\u0180DTV\u1063\u106e\u1078ownVector;\u694feeVector;\u695cector\u0100;B\u1082\u1083\u61bear;\u6954ector\u0100;B\u1091\u1092\u61c0ar;\u6953\u0100pu\u109b\u109ef;\u611dndImplies;\u6970ightarrow;\u61db\u0100ch\u10b9\u10bcr;\u611b;\u61b1leDelayed;\u69f4\u0680HOacfhimoqstu\u10e4\u10f1\u10f7\u10fd\u1119\u111e\u1151\u1156\u1161\u1167\u11b5\u11bb\u11bf\u0100Cc\u10e9\u10eeHcy;\u4429y;\u4428FTcy;\u442ccute;\u415a\u0280;aeiy\u1108\u1109\u110e\u1113\u1117\u6abcron;\u4160dil;\u415erc;\u415c;\u4421r;\uc000\ud835\udd16ort\u0200DLRU\u112a\u1134\u113e\u1149ownArrow\xbb\u041eeftArrow\xbb\u089aightArrow\xbb\u0fddpArrow;\u6191gma;\u43a3allCircle;\u6218pf;\uc000\ud835\udd4a\u0272\u116d\0\0\u1170t;\u621aare\u0200;ISU\u117b\u117c\u1189\u11af\u65a1ntersection;\u6293u\u0100bp\u118f\u119eset\u0100;E\u1197\u1198\u628fqual;\u6291erset\u0100;E\u11a8\u11a9\u6290qual;\u6292nion;\u6294cr;\uc000\ud835\udcaear;\u62c6\u0200bcmp\u11c8\u11db\u1209\u120b\u0100;s\u11cd\u11ce\u62d0et\u0100;E\u11cd\u11d5qual;\u6286\u0100ch\u11e0\u1205eeds\u0200;EST\u11ed\u11ee\u11f4\u11ff\u627bqual;\u6ab0lantEqual;\u627dilde;\u627fTh\xe1\u0f8c;\u6211\u0180;es\u1212\u1213\u1223\u62d1rset\u0100;E\u121c\u121d\u6283qual;\u6287et\xbb\u1213\u0580HRSacfhiors\u123e\u1244\u1249\u1255\u125e\u1271\u1276\u129f\u12c2\u12c8\u12d1ORN\u803b\xde\u40deADE;\u6122\u0100Hc\u124e\u1252cy;\u440by;\u4426\u0100bu\u125a\u125c;\u4009;\u43a4\u0180aey\u1265\u126a\u126fron;\u4164dil;\u4162;\u4422r;\uc000\ud835\udd17\u0100ei\u127b\u1289\u01f2\u1280\0\u1287efore;\u6234a;\u4398\u0100cn\u128e\u1298kSpace;\uc000\u205f\u200aSpace;\u6009lde\u0200;EFT\u12ab\u12ac\u12b2\u12bc\u623cqual;\u6243ullEqual;\u6245ilde;\u6248pf;\uc000\ud835\udd4bipleDot;\u60db\u0100ct\u12d6\u12dbr;\uc000\ud835\udcafrok;\u4166\u0ae1\u12f7\u130e\u131a\u1326\0\u132c\u1331\0\0\0\0\0\u1338\u133d\u1377\u1385\0\u13ff\u1404\u140a\u1410\u0100cr\u12fb\u1301ute\u803b\xda\u40dar\u0100;o\u1307\u1308\u619fcir;\u6949r\u01e3\u1313\0\u1316y;\u440eve;\u416c\u0100iy\u131e\u1323rc\u803b\xdb\u40db;\u4423blac;\u4170r;\uc000\ud835\udd18rave\u803b\xd9\u40d9acr;\u416a\u0100di\u1341\u1369er\u0100BP\u1348\u135d\u0100ar\u134d\u1350r;\u405fac\u0100ek\u1357\u1359;\u63dfet;\u63b5arenthesis;\u63ddon\u0100;P\u1370\u1371\u62c3lus;\u628e\u0100gp\u137b\u137fon;\u4172f;\uc000\ud835\udd4c\u0400ADETadps\u1395\u13ae\u13b8\u13c4\u03e8\u13d2\u13d7\u13f3rrow\u0180;BD\u1150\u13a0\u13a4ar;\u6912ownArrow;\u61c5ownArrow;\u6195quilibrium;\u696eee\u0100;A\u13cb\u13cc\u62a5rrow;\u61a5own\xe1\u03f3er\u0100LR\u13de\u13e8eftArrow;\u6196ightArrow;\u6197i\u0100;l\u13f9\u13fa\u43d2on;\u43a5ing;\u416ecr;\uc000\ud835\udcb0ilde;\u4168ml\u803b\xdc\u40dc\u0480Dbcdefosv\u1427\u142c\u1430\u1433\u143e\u1485\u148a\u1490\u1496ash;\u62abar;\u6aeby;\u4412ash\u0100;l\u143b\u143c\u62a9;\u6ae6\u0100er\u1443\u1445;\u62c1\u0180bty\u144c\u1450\u147aar;\u6016\u0100;i\u144f\u1455cal\u0200BLST\u1461\u1465\u146a\u1474ar;\u6223ine;\u407ceparator;\u6758ilde;\u6240ThinSpace;\u600ar;\uc000\ud835\udd19pf;\uc000\ud835\udd4dcr;\uc000\ud835\udcb1dash;\u62aa\u0280cefos\u14a7\u14ac\u14b1\u14b6\u14bcirc;\u4174dge;\u62c0r;\uc000\ud835\udd1apf;\uc000\ud835\udd4ecr;\uc000\ud835\udcb2\u0200fios\u14cb\u14d0\u14d2\u14d8r;\uc000\ud835\udd1b;\u439epf;\uc000\ud835\udd4fcr;\uc000\ud835\udcb3\u0480AIUacfosu\u14f1\u14f5\u14f9\u14fd\u1504\u150f\u1514\u151a\u1520cy;\u442fcy;\u4407cy;\u442ecute\u803b\xdd\u40dd\u0100iy\u1509\u150drc;\u4176;\u442br;\uc000\ud835\udd1cpf;\uc000\ud835\udd50cr;\uc000\ud835\udcb4ml;\u4178\u0400Hacdefos\u1535\u1539\u153f\u154b\u154f\u155d\u1560\u1564cy;\u4416cute;\u4179\u0100ay\u1544\u1549ron;\u417d;\u4417ot;\u417b\u01f2\u1554\0\u155boWidt\xe8\u0ad9a;\u4396r;\u6128pf;\u6124cr;\uc000\ud835\udcb5\u0be1\u1583\u158a\u1590\0\u15b0\u15b6\u15bf\0\0\0\0\u15c6\u15db\u15eb\u165f\u166d\0\u1695\u169b\u16b2\u16b9\0\u16becute\u803b\xe1\u40e1reve;\u4103\u0300;Ediuy\u159c\u159d\u15a1\u15a3\u15a8\u15ad\u623e;\uc000\u223e\u0333;\u623frc\u803b\xe2\u40e2te\u80bb\xb4\u0306;\u4430lig\u803b\xe6\u40e6\u0100;r\xb2\u15ba;\uc000\ud835\udd1erave\u803b\xe0\u40e0\u0100ep\u15ca\u15d6\u0100fp\u15cf\u15d4sym;\u6135\xe8\u15d3ha;\u43b1\u0100ap\u15dfc\u0100cl\u15e4\u15e7r;\u4101g;\u6a3f\u0264\u15f0\0\0\u160a\u0280;adsv\u15fa\u15fb\u15ff\u1601\u1607\u6227nd;\u6a55;\u6a5clope;\u6a58;\u6a5a\u0380;elmrsz\u1618\u1619\u161b\u161e\u163f\u164f\u1659\u6220;\u69a4e\xbb\u1619sd\u0100;a\u1625\u1626\u6221\u0461\u1630\u1632\u1634\u1636\u1638\u163a\u163c\u163e;\u69a8;\u69a9;\u69aa;\u69ab;\u69ac;\u69ad;\u69ae;\u69aft\u0100;v\u1645\u1646\u621fb\u0100;d\u164c\u164d\u62be;\u699d\u0100pt\u1654\u1657h;\u6222\xbb\xb9arr;\u637c\u0100gp\u1663\u1667on;\u4105f;\uc000\ud835\udd52\u0380;Eaeiop\u12c1\u167b\u167d\u1682\u1684\u1687\u168a;\u6a70cir;\u6a6f;\u624ad;\u624bs;\u4027rox\u0100;e\u12c1\u1692\xf1\u1683ing\u803b\xe5\u40e5\u0180cty\u16a1\u16a6\u16a8r;\uc000\ud835\udcb6;\u402amp\u0100;e\u12c1\u16af\xf1\u0288ilde\u803b\xe3\u40e3ml\u803b\xe4\u40e4\u0100ci\u16c2\u16c8onin\xf4\u0272nt;\u6a11\u0800Nabcdefiklnoprsu\u16ed\u16f1\u1730\u173c\u1743\u1748\u1778\u177d\u17e0\u17e6\u1839\u1850\u170d\u193d\u1948\u1970ot;\u6aed\u0100cr\u16f6\u171ek\u0200ceps\u1700\u1705\u170d\u1713ong;\u624cpsilon;\u43f6rime;\u6035im\u0100;e\u171a\u171b\u623dq;\u62cd\u0176\u1722\u1726ee;\u62bded\u0100;g\u172c\u172d\u6305e\xbb\u172drk\u0100;t\u135c\u1737brk;\u63b6\u0100oy\u1701\u1741;\u4431quo;\u601e\u0280cmprt\u1753\u175b\u1761\u1764\u1768aus\u0100;e\u010a\u0109ptyv;\u69b0s\xe9\u170cno\xf5\u0113\u0180ahw\u176f\u1771\u1773;\u43b2;\u6136een;\u626cr;\uc000\ud835\udd1fg\u0380costuvw\u178d\u179d\u17b3\u17c1\u17d5\u17db\u17de\u0180aiu\u1794\u1796\u179a\xf0\u0760rc;\u65efp\xbb\u1371\u0180dpt\u17a4\u17a8\u17adot;\u6a00lus;\u6a01imes;\u6a02\u0271\u17b9\0\0\u17becup;\u6a06ar;\u6605riangle\u0100du\u17cd\u17d2own;\u65bdp;\u65b3plus;\u6a04e\xe5\u1444\xe5\u14adarow;\u690d\u0180ako\u17ed\u1826\u1835\u0100cn\u17f2\u1823k\u0180lst\u17fa\u05ab\u1802ozenge;\u69ebriangle\u0200;dlr\u1812\u1813\u1818\u181d\u65b4own;\u65beeft;\u65c2ight;\u65b8k;\u6423\u01b1\u182b\0\u1833\u01b2\u182f\0\u1831;\u6592;\u65914;\u6593ck;\u6588\u0100eo\u183e\u184d\u0100;q\u1843\u1846\uc000=\u20e5uiv;\uc000\u2261\u20e5t;\u6310\u0200ptwx\u1859\u185e\u1867\u186cf;\uc000\ud835\udd53\u0100;t\u13cb\u1863om\xbb\u13cctie;\u62c8\u0600DHUVbdhmptuv\u1885\u1896\u18aa\u18bb\u18d7\u18db\u18ec\u18ff\u1905\u190a\u1910\u1921\u0200LRlr\u188e\u1890\u1892\u1894;\u6557;\u6554;\u6556;\u6553\u0280;DUdu\u18a1\u18a2\u18a4\u18a6\u18a8\u6550;\u6566;\u6569;\u6564;\u6567\u0200LRlr\u18b3\u18b5\u18b7\u18b9;\u655d;\u655a;\u655c;\u6559\u0380;HLRhlr\u18ca\u18cb\u18cd\u18cf\u18d1\u18d3\u18d5\u6551;\u656c;\u6563;\u6560;\u656b;\u6562;\u655fox;\u69c9\u0200LRlr\u18e4\u18e6\u18e8\u18ea;\u6555;\u6552;\u6510;\u650c\u0280;DUdu\u06bd\u18f7\u18f9\u18fb\u18fd;\u6565;\u6568;\u652c;\u6534inus;\u629flus;\u629eimes;\u62a0\u0200LRlr\u1919\u191b\u191d\u191f;\u655b;\u6558;\u6518;\u6514\u0380;HLRhlr\u1930\u1931\u1933\u1935\u1937\u1939\u193b\u6502;\u656a;\u6561;\u655e;\u653c;\u6524;\u651c\u0100ev\u0123\u1942bar\u803b\xa6\u40a6\u0200ceio\u1951\u1956\u195a\u1960r;\uc000\ud835\udcb7mi;\u604fm\u0100;e\u171a\u171cl\u0180;bh\u1968\u1969\u196b\u405c;\u69c5sub;\u67c8\u016c\u1974\u197el\u0100;e\u1979\u197a\u6022t\xbb\u197ap\u0180;Ee\u012f\u1985\u1987;\u6aae\u0100;q\u06dc\u06db\u0ce1\u19a7\0\u19e8\u1a11\u1a15\u1a32\0\u1a37\u1a50\0\0\u1ab4\0\0\u1ac1\0\0\u1b21\u1b2e\u1b4d\u1b52\0\u1bfd\0\u1c0c\u0180cpr\u19ad\u19b2\u19ddute;\u4107\u0300;abcds\u19bf\u19c0\u19c4\u19ca\u19d5\u19d9\u6229nd;\u6a44rcup;\u6a49\u0100au\u19cf\u19d2p;\u6a4bp;\u6a47ot;\u6a40;\uc000\u2229\ufe00\u0100eo\u19e2\u19e5t;\u6041\xee\u0693\u0200aeiu\u19f0\u19fb\u1a01\u1a05\u01f0\u19f5\0\u19f8s;\u6a4don;\u410ddil\u803b\xe7\u40e7rc;\u4109ps\u0100;s\u1a0c\u1a0d\u6a4cm;\u6a50ot;\u410b\u0180dmn\u1a1b\u1a20\u1a26il\u80bb\xb8\u01adptyv;\u69b2t\u8100\xa2;e\u1a2d\u1a2e\u40a2r\xe4\u01b2r;\uc000\ud835\udd20\u0180cei\u1a3d\u1a40\u1a4dy;\u4447ck\u0100;m\u1a47\u1a48\u6713ark\xbb\u1a48;\u43c7r\u0380;Ecefms\u1a5f\u1a60\u1a62\u1a6b\u1aa4\u1aaa\u1aae\u65cb;\u69c3\u0180;el\u1a69\u1a6a\u1a6d\u42c6q;\u6257e\u0261\u1a74\0\0\u1a88rrow\u0100lr\u1a7c\u1a81eft;\u61baight;\u61bb\u0280RSacd\u1a92\u1a94\u1a96\u1a9a\u1a9f\xbb\u0f47;\u64c8st;\u629birc;\u629aash;\u629dnint;\u6a10id;\u6aefcir;\u69c2ubs\u0100;u\u1abb\u1abc\u6663it\xbb\u1abc\u02ec\u1ac7\u1ad4\u1afa\0\u1b0aon\u0100;e\u1acd\u1ace\u403a\u0100;q\xc7\xc6\u026d\u1ad9\0\0\u1ae2a\u0100;t\u1ade\u1adf\u402c;\u4040\u0180;fl\u1ae8\u1ae9\u1aeb\u6201\xee\u1160e\u0100mx\u1af1\u1af6ent\xbb\u1ae9e\xf3\u024d\u01e7\u1afe\0\u1b07\u0100;d\u12bb\u1b02ot;\u6a6dn\xf4\u0246\u0180fry\u1b10\u1b14\u1b17;\uc000\ud835\udd54o\xe4\u0254\u8100\xa9;s\u0155\u1b1dr;\u6117\u0100ao\u1b25\u1b29rr;\u61b5ss;\u6717\u0100cu\u1b32\u1b37r;\uc000\ud835\udcb8\u0100bp\u1b3c\u1b44\u0100;e\u1b41\u1b42\u6acf;\u6ad1\u0100;e\u1b49\u1b4a\u6ad0;\u6ad2dot;\u62ef\u0380delprvw\u1b60\u1b6c\u1b77\u1b82\u1bac\u1bd4\u1bf9arr\u0100lr\u1b68\u1b6a;\u6938;\u6935\u0270\u1b72\0\0\u1b75r;\u62dec;\u62dfarr\u0100;p\u1b7f\u1b80\u61b6;\u693d\u0300;bcdos\u1b8f\u1b90\u1b96\u1ba1\u1ba5\u1ba8\u622arcap;\u6a48\u0100au\u1b9b\u1b9ep;\u6a46p;\u6a4aot;\u628dr;\u6a45;\uc000\u222a\ufe00\u0200alrv\u1bb5\u1bbf\u1bde\u1be3rr\u0100;m\u1bbc\u1bbd\u61b7;\u693cy\u0180evw\u1bc7\u1bd4\u1bd8q\u0270\u1bce\0\0\u1bd2re\xe3\u1b73u\xe3\u1b75ee;\u62ceedge;\u62cfen\u803b\xa4\u40a4earrow\u0100lr\u1bee\u1bf3eft\xbb\u1b80ight\xbb\u1bbde\xe4\u1bdd\u0100ci\u1c01\u1c07onin\xf4\u01f7nt;\u6231lcty;\u632d\u0980AHabcdefhijlorstuwz\u1c38\u1c3b\u1c3f\u1c5d\u1c69\u1c75\u1c8a\u1c9e\u1cac\u1cb7\u1cfb\u1cff\u1d0d\u1d7b\u1d91\u1dab\u1dbb\u1dc6\u1dcdr\xf2\u0381ar;\u6965\u0200glrs\u1c48\u1c4d\u1c52\u1c54ger;\u6020eth;\u6138\xf2\u1133h\u0100;v\u1c5a\u1c5b\u6010\xbb\u090a\u016b\u1c61\u1c67arow;\u690fa\xe3\u0315\u0100ay\u1c6e\u1c73ron;\u410f;\u4434\u0180;ao\u0332\u1c7c\u1c84\u0100gr\u02bf\u1c81r;\u61catseq;\u6a77\u0180glm\u1c91\u1c94\u1c98\u803b\xb0\u40b0ta;\u43b4ptyv;\u69b1\u0100ir\u1ca3\u1ca8sht;\u697f;\uc000\ud835\udd21ar\u0100lr\u1cb3\u1cb5\xbb\u08dc\xbb\u101e\u0280aegsv\u1cc2\u0378\u1cd6\u1cdc\u1ce0m\u0180;os\u0326\u1cca\u1cd4nd\u0100;s\u0326\u1cd1uit;\u6666amma;\u43ddin;\u62f2\u0180;io\u1ce7\u1ce8\u1cf8\u40f7de\u8100\xf7;o\u1ce7\u1cf0ntimes;\u62c7n\xf8\u1cf7cy;\u4452c\u026f\u1d06\0\0\u1d0arn;\u631eop;\u630d\u0280lptuw\u1d18\u1d1d\u1d22\u1d49\u1d55lar;\u4024f;\uc000\ud835\udd55\u0280;emps\u030b\u1d2d\u1d37\u1d3d\u1d42q\u0100;d\u0352\u1d33ot;\u6251inus;\u6238lus;\u6214quare;\u62a1blebarwedg\xe5\xfan\u0180adh\u112e\u1d5d\u1d67ownarrow\xf3\u1c83arpoon\u0100lr\u1d72\u1d76ef\xf4\u1cb4igh\xf4\u1cb6\u0162\u1d7f\u1d85karo\xf7\u0f42\u026f\u1d8a\0\0\u1d8ern;\u631fop;\u630c\u0180cot\u1d98\u1da3\u1da6\u0100ry\u1d9d\u1da1;\uc000\ud835\udcb9;\u4455l;\u69f6rok;\u4111\u0100dr\u1db0\u1db4ot;\u62f1i\u0100;f\u1dba\u1816\u65bf\u0100ah\u1dc0\u1dc3r\xf2\u0429a\xf2\u0fa6angle;\u69a6\u0100ci\u1dd2\u1dd5y;\u445fgrarr;\u67ff\u0900Dacdefglmnopqrstux\u1e01\u1e09\u1e19\u1e38\u0578\u1e3c\u1e49\u1e61\u1e7e\u1ea5\u1eaf\u1ebd\u1ee1\u1f2a\u1f37\u1f44\u1f4e\u1f5a\u0100Do\u1e06\u1d34o\xf4\u1c89\u0100cs\u1e0e\u1e14ute\u803b\xe9\u40e9ter;\u6a6e\u0200aioy\u1e22\u1e27\u1e31\u1e36ron;\u411br\u0100;c\u1e2d\u1e2e\u6256\u803b\xea\u40ealon;\u6255;\u444dot;\u4117\u0100Dr\u1e41\u1e45ot;\u6252;\uc000\ud835\udd22\u0180;rs\u1e50\u1e51\u1e57\u6a9aave\u803b\xe8\u40e8\u0100;d\u1e5c\u1e5d\u6a96ot;\u6a98\u0200;ils\u1e6a\u1e6b\u1e72\u1e74\u6a99nters;\u63e7;\u6113\u0100;d\u1e79\u1e7a\u6a95ot;\u6a97\u0180aps\u1e85\u1e89\u1e97cr;\u4113ty\u0180;sv\u1e92\u1e93\u1e95\u6205et\xbb\u1e93p\u01001;\u1e9d\u1ea4\u0133\u1ea1\u1ea3;\u6004;\u6005\u6003\u0100gs\u1eaa\u1eac;\u414bp;\u6002\u0100gp\u1eb4\u1eb8on;\u4119f;\uc000\ud835\udd56\u0180als\u1ec4\u1ece\u1ed2r\u0100;s\u1eca\u1ecb\u62d5l;\u69e3us;\u6a71i\u0180;lv\u1eda\u1edb\u1edf\u43b5on\xbb\u1edb;\u43f5\u0200csuv\u1eea\u1ef3\u1f0b\u1f23\u0100io\u1eef\u1e31rc\xbb\u1e2e\u0269\u1ef9\0\0\u1efb\xed\u0548ant\u0100gl\u1f02\u1f06tr\xbb\u1e5dess\xbb\u1e7a\u0180aei\u1f12\u1f16\u1f1als;\u403dst;\u625fv\u0100;D\u0235\u1f20D;\u6a78parsl;\u69e5\u0100Da\u1f2f\u1f33ot;\u6253rr;\u6971\u0180cdi\u1f3e\u1f41\u1ef8r;\u612fo\xf4\u0352\u0100ah\u1f49\u1f4b;\u43b7\u803b\xf0\u40f0\u0100mr\u1f53\u1f57l\u803b\xeb\u40ebo;\u60ac\u0180cip\u1f61\u1f64\u1f67l;\u4021s\xf4\u056e\u0100eo\u1f6c\u1f74ctatio\xee\u0559nential\xe5\u0579\u09e1\u1f92\0\u1f9e\0\u1fa1\u1fa7\0\0\u1fc6\u1fcc\0\u1fd3\0\u1fe6\u1fea\u2000\0\u2008\u205allingdotse\xf1\u1e44y;\u4444male;\u6640\u0180ilr\u1fad\u1fb3\u1fc1lig;\u8000\ufb03\u0269\u1fb9\0\0\u1fbdg;\u8000\ufb00ig;\u8000\ufb04;\uc000\ud835\udd23lig;\u8000\ufb01lig;\uc000fj\u0180alt\u1fd9\u1fdc\u1fe1t;\u666dig;\u8000\ufb02ns;\u65b1of;\u4192\u01f0\u1fee\0\u1ff3f;\uc000\ud835\udd57\u0100ak\u05bf\u1ff7\u0100;v\u1ffc\u1ffd\u62d4;\u6ad9artint;\u6a0d\u0100ao\u200c\u2055\u0100cs\u2011\u2052\u03b1\u201a\u2030\u2038\u2045\u2048\0\u2050\u03b2\u2022\u2025\u2027\u202a\u202c\0\u202e\u803b\xbd\u40bd;\u6153\u803b\xbc\u40bc;\u6155;\u6159;\u615b\u01b3\u2034\0\u2036;\u6154;\u6156\u02b4\u203e\u2041\0\0\u2043\u803b\xbe\u40be;\u6157;\u615c5;\u6158\u01b6\u204c\0\u204e;\u615a;\u615d8;\u615el;\u6044wn;\u6322cr;\uc000\ud835\udcbb\u0880Eabcdefgijlnorstv\u2082\u2089\u209f\u20a5\u20b0\u20b4\u20f0\u20f5\u20fa\u20ff\u2103\u2112\u2138\u0317\u213e\u2152\u219e\u0100;l\u064d\u2087;\u6a8c\u0180cmp\u2090\u2095\u209dute;\u41f5ma\u0100;d\u209c\u1cda\u43b3;\u6a86reve;\u411f\u0100iy\u20aa\u20aerc;\u411d;\u4433ot;\u4121\u0200;lqs\u063e\u0642\u20bd\u20c9\u0180;qs\u063e\u064c\u20c4lan\xf4\u0665\u0200;cdl\u0665\u20d2\u20d5\u20e5c;\u6aa9ot\u0100;o\u20dc\u20dd\u6a80\u0100;l\u20e2\u20e3\u6a82;\u6a84\u0100;e\u20ea\u20ed\uc000\u22db\ufe00s;\u6a94r;\uc000\ud835\udd24\u0100;g\u0673\u061bmel;\u6137cy;\u4453\u0200;Eaj\u065a\u210c\u210e\u2110;\u6a92;\u6aa5;\u6aa4\u0200Eaes\u211b\u211d\u2129\u2134;\u6269p\u0100;p\u2123\u2124\u6a8arox\xbb\u2124\u0100;q\u212e\u212f\u6a88\u0100;q\u212e\u211bim;\u62e7pf;\uc000\ud835\udd58\u0100ci\u2143\u2146r;\u610am\u0180;el\u066b\u214e\u2150;\u6a8e;\u6a90\u8300>;cdlqr\u05ee\u2160\u216a\u216e\u2173\u2179\u0100ci\u2165\u2167;\u6aa7r;\u6a7aot;\u62d7Par;\u6995uest;\u6a7c\u0280adels\u2184\u216a\u2190\u0656\u219b\u01f0\u2189\0\u218epro\xf8\u209er;\u6978q\u0100lq\u063f\u2196les\xf3\u2088i\xed\u066b\u0100en\u21a3\u21adrtneqq;\uc000\u2269\ufe00\xc5\u21aa\u0500Aabcefkosy\u21c4\u21c7\u21f1\u21f5\u21fa\u2218\u221d\u222f\u2268\u227dr\xf2\u03a0\u0200ilmr\u21d0\u21d4\u21d7\u21dbrs\xf0\u1484f\xbb\u2024il\xf4\u06a9\u0100dr\u21e0\u21e4cy;\u444a\u0180;cw\u08f4\u21eb\u21efir;\u6948;\u61adar;\u610firc;\u4125\u0180alr\u2201\u220e\u2213rts\u0100;u\u2209\u220a\u6665it\xbb\u220alip;\u6026con;\u62b9r;\uc000\ud835\udd25s\u0100ew\u2223\u2229arow;\u6925arow;\u6926\u0280amopr\u223a\u223e\u2243\u225e\u2263rr;\u61fftht;\u623bk\u0100lr\u2249\u2253eftarrow;\u61a9ightarrow;\u61aaf;\uc000\ud835\udd59bar;\u6015\u0180clt\u226f\u2274\u2278r;\uc000\ud835\udcbdas\xe8\u21f4rok;\u4127\u0100bp\u2282\u2287ull;\u6043hen\xbb\u1c5b\u0ae1\u22a3\0\u22aa\0\u22b8\u22c5\u22ce\0\u22d5\u22f3\0\0\u22f8\u2322\u2367\u2362\u237f\0\u2386\u23aa\u23b4cute\u803b\xed\u40ed\u0180;iy\u0771\u22b0\u22b5rc\u803b\xee\u40ee;\u4438\u0100cx\u22bc\u22bfy;\u4435cl\u803b\xa1\u40a1\u0100fr\u039f\u22c9;\uc000\ud835\udd26rave\u803b\xec\u40ec\u0200;ino\u073e\u22dd\u22e9\u22ee\u0100in\u22e2\u22e6nt;\u6a0ct;\u622dfin;\u69dcta;\u6129lig;\u4133\u0180aop\u22fe\u231a\u231d\u0180cgt\u2305\u2308\u2317r;\u412b\u0180elp\u071f\u230f\u2313in\xe5\u078ear\xf4\u0720h;\u4131f;\u62b7ed;\u41b5\u0280;cfot\u04f4\u232c\u2331\u233d\u2341are;\u6105in\u0100;t\u2338\u2339\u621eie;\u69dddo\xf4\u2319\u0280;celp\u0757\u234c\u2350\u235b\u2361al;\u62ba\u0100gr\u2355\u2359er\xf3\u1563\xe3\u234darhk;\u6a17rod;\u6a3c\u0200cgpt\u236f\u2372\u2376\u237by;\u4451on;\u412ff;\uc000\ud835\udd5aa;\u43b9uest\u803b\xbf\u40bf\u0100ci\u238a\u238fr;\uc000\ud835\udcben\u0280;Edsv\u04f4\u239b\u239d\u23a1\u04f3;\u62f9ot;\u62f5\u0100;v\u23a6\u23a7\u62f4;\u62f3\u0100;i\u0777\u23aelde;\u4129\u01eb\u23b8\0\u23bccy;\u4456l\u803b\xef\u40ef\u0300cfmosu\u23cc\u23d7\u23dc\u23e1\u23e7\u23f5\u0100iy\u23d1\u23d5rc;\u4135;\u4439r;\uc000\ud835\udd27ath;\u4237pf;\uc000\ud835\udd5b\u01e3\u23ec\0\u23f1r;\uc000\ud835\udcbfrcy;\u4458kcy;\u4454\u0400acfghjos\u240b\u2416\u2422\u2427\u242d\u2431\u2435\u243bppa\u0100;v\u2413\u2414\u43ba;\u43f0\u0100ey\u241b\u2420dil;\u4137;\u443ar;\uc000\ud835\udd28reen;\u4138cy;\u4445cy;\u445cpf;\uc000\ud835\udd5ccr;\uc000\ud835\udcc0\u0b80ABEHabcdefghjlmnoprstuv\u2470\u2481\u2486\u248d\u2491\u250e\u253d\u255a\u2580\u264e\u265e\u2665\u2679\u267d\u269a\u26b2\u26d8\u275d\u2768\u278b\u27c0\u2801\u2812\u0180art\u2477\u247a\u247cr\xf2\u09c6\xf2\u0395ail;\u691barr;\u690e\u0100;g\u0994\u248b;\u6a8bar;\u6962\u0963\u24a5\0\u24aa\0\u24b1\0\0\0\0\0\u24b5\u24ba\0\u24c6\u24c8\u24cd\0\u24f9ute;\u413amptyv;\u69b4ra\xee\u084cbda;\u43bbg\u0180;dl\u088e\u24c1\u24c3;\u6991\xe5\u088e;\u6a85uo\u803b\xab\u40abr\u0400;bfhlpst\u0899\u24de\u24e6\u24e9\u24eb\u24ee\u24f1\u24f5\u0100;f\u089d\u24e3s;\u691fs;\u691d\xeb\u2252p;\u61abl;\u6939im;\u6973l;\u61a2\u0180;ae\u24ff\u2500\u2504\u6aabil;\u6919\u0100;s\u2509\u250a\u6aad;\uc000\u2aad\ufe00\u0180abr\u2515\u2519\u251drr;\u690crk;\u6772\u0100ak\u2522\u252cc\u0100ek\u2528\u252a;\u407b;\u405b\u0100es\u2531\u2533;\u698bl\u0100du\u2539\u253b;\u698f;\u698d\u0200aeuy\u2546\u254b\u2556\u2558ron;\u413e\u0100di\u2550\u2554il;\u413c\xec\u08b0\xe2\u2529;\u443b\u0200cqrs\u2563\u2566\u256d\u257da;\u6936uo\u0100;r\u0e19\u1746\u0100du\u2572\u2577har;\u6967shar;\u694bh;\u61b2\u0280;fgqs\u258b\u258c\u0989\u25f3\u25ff\u6264t\u0280ahlrt\u2598\u25a4\u25b7\u25c2\u25e8rrow\u0100;t\u0899\u25a1a\xe9\u24f6arpoon\u0100du\u25af\u25b4own\xbb\u045ap\xbb\u0966eftarrows;\u61c7ight\u0180ahs\u25cd\u25d6\u25derrow\u0100;s\u08f4\u08a7arpoon\xf3\u0f98quigarro\xf7\u21f0hreetimes;\u62cb\u0180;qs\u258b\u0993\u25falan\xf4\u09ac\u0280;cdgs\u09ac\u260a\u260d\u261d\u2628c;\u6aa8ot\u0100;o\u2614\u2615\u6a7f\u0100;r\u261a\u261b\u6a81;\u6a83\u0100;e\u2622\u2625\uc000\u22da\ufe00s;\u6a93\u0280adegs\u2633\u2639\u263d\u2649\u264bppro\xf8\u24c6ot;\u62d6q\u0100gq\u2643\u2645\xf4\u0989gt\xf2\u248c\xf4\u099bi\xed\u09b2\u0180ilr\u2655\u08e1\u265asht;\u697c;\uc000\ud835\udd29\u0100;E\u099c\u2663;\u6a91\u0161\u2669\u2676r\u0100du\u25b2\u266e\u0100;l\u0965\u2673;\u696alk;\u6584cy;\u4459\u0280;acht\u0a48\u2688\u268b\u2691\u2696r\xf2\u25c1orne\xf2\u1d08ard;\u696bri;\u65fa\u0100io\u269f\u26a4dot;\u4140ust\u0100;a\u26ac\u26ad\u63b0che\xbb\u26ad\u0200Eaes\u26bb\u26bd\u26c9\u26d4;\u6268p\u0100;p\u26c3\u26c4\u6a89rox\xbb\u26c4\u0100;q\u26ce\u26cf\u6a87\u0100;q\u26ce\u26bbim;\u62e6\u0400abnoptwz\u26e9\u26f4\u26f7\u271a\u272f\u2741\u2747\u2750\u0100nr\u26ee\u26f1g;\u67ecr;\u61fdr\xeb\u08c1g\u0180lmr\u26ff\u270d\u2714eft\u0100ar\u09e6\u2707ight\xe1\u09f2apsto;\u67fcight\xe1\u09fdparrow\u0100lr\u2725\u2729ef\xf4\u24edight;\u61ac\u0180afl\u2736\u2739\u273dr;\u6985;\uc000\ud835\udd5dus;\u6a2dimes;\u6a34\u0161\u274b\u274fst;\u6217\xe1\u134e\u0180;ef\u2757\u2758\u1800\u65cange\xbb\u2758ar\u0100;l\u2764\u2765\u4028t;\u6993\u0280achmt\u2773\u2776\u277c\u2785\u2787r\xf2\u08a8orne\xf2\u1d8car\u0100;d\u0f98\u2783;\u696d;\u600eri;\u62bf\u0300achiqt\u2798\u279d\u0a40\u27a2\u27ae\u27bbquo;\u6039r;\uc000\ud835\udcc1m\u0180;eg\u09b2\u27aa\u27ac;\u6a8d;\u6a8f\u0100bu\u252a\u27b3o\u0100;r\u0e1f\u27b9;\u601arok;\u4142\u8400<;cdhilqr\u082b\u27d2\u2639\u27dc\u27e0\u27e5\u27ea\u27f0\u0100ci\u27d7\u27d9;\u6aa6r;\u6a79re\xe5\u25f2mes;\u62c9arr;\u6976uest;\u6a7b\u0100Pi\u27f5\u27f9ar;\u6996\u0180;ef\u2800\u092d\u181b\u65c3r\u0100du\u2807\u280dshar;\u694ahar;\u6966\u0100en\u2817\u2821rtneqq;\uc000\u2268\ufe00\xc5\u281e\u0700Dacdefhilnopsu\u2840\u2845\u2882\u288e\u2893\u28a0\u28a5\u28a8\u28da\u28e2\u28e4\u0a83\u28f3\u2902Dot;\u623a\u0200clpr\u284e\u2852\u2863\u287dr\u803b\xaf\u40af\u0100et\u2857\u2859;\u6642\u0100;e\u285e\u285f\u6720se\xbb\u285f\u0100;s\u103b\u2868to\u0200;dlu\u103b\u2873\u2877\u287bow\xee\u048cef\xf4\u090f\xf0\u13d1ker;\u65ae\u0100oy\u2887\u288cmma;\u6a29;\u443cash;\u6014asuredangle\xbb\u1626r;\uc000\ud835\udd2ao;\u6127\u0180cdn\u28af\u28b4\u28c9ro\u803b\xb5\u40b5\u0200;acd\u1464\u28bd\u28c0\u28c4s\xf4\u16a7ir;\u6af0ot\u80bb\xb7\u01b5us\u0180;bd\u28d2\u1903\u28d3\u6212\u0100;u\u1d3c\u28d8;\u6a2a\u0163\u28de\u28e1p;\u6adb\xf2\u2212\xf0\u0a81\u0100dp\u28e9\u28eeels;\u62a7f;\uc000\ud835\udd5e\u0100ct\u28f8\u28fdr;\uc000\ud835\udcc2pos\xbb\u159d\u0180;lm\u2909\u290a\u290d\u43bctimap;\u62b8\u0c00GLRVabcdefghijlmoprstuvw\u2942\u2953\u297e\u2989\u2998\u29da\u29e9\u2a15\u2a1a\u2a58\u2a5d\u2a83\u2a95\u2aa4\u2aa8\u2b04\u2b07\u2b44\u2b7f\u2bae\u2c34\u2c67\u2c7c\u2ce9\u0100gt\u2947\u294b;\uc000\u22d9\u0338\u0100;v\u2950\u0bcf\uc000\u226b\u20d2\u0180elt\u295a\u2972\u2976ft\u0100ar\u2961\u2967rrow;\u61cdightarrow;\u61ce;\uc000\u22d8\u0338\u0100;v\u297b\u0c47\uc000\u226a\u20d2ightarrow;\u61cf\u0100Dd\u298e\u2993ash;\u62afash;\u62ae\u0280bcnpt\u29a3\u29a7\u29ac\u29b1\u29ccla\xbb\u02deute;\u4144g;\uc000\u2220\u20d2\u0280;Eiop\u0d84\u29bc\u29c0\u29c5\u29c8;\uc000\u2a70\u0338d;\uc000\u224b\u0338s;\u4149ro\xf8\u0d84ur\u0100;a\u29d3\u29d4\u666el\u0100;s\u29d3\u0b38\u01f3\u29df\0\u29e3p\u80bb\xa0\u0b37mp\u0100;e\u0bf9\u0c00\u0280aeouy\u29f4\u29fe\u2a03\u2a10\u2a13\u01f0\u29f9\0\u29fb;\u6a43on;\u4148dil;\u4146ng\u0100;d\u0d7e\u2a0aot;\uc000\u2a6d\u0338p;\u6a42;\u443dash;\u6013\u0380;Aadqsx\u0b92\u2a29\u2a2d\u2a3b\u2a41\u2a45\u2a50rr;\u61d7r\u0100hr\u2a33\u2a36k;\u6924\u0100;o\u13f2\u13f0ot;\uc000\u2250\u0338ui\xf6\u0b63\u0100ei\u2a4a\u2a4ear;\u6928\xed\u0b98ist\u0100;s\u0ba0\u0b9fr;\uc000\ud835\udd2b\u0200Eest\u0bc5\u2a66\u2a79\u2a7c\u0180;qs\u0bbc\u2a6d\u0be1\u0180;qs\u0bbc\u0bc5\u2a74lan\xf4\u0be2i\xed\u0bea\u0100;r\u0bb6\u2a81\xbb\u0bb7\u0180Aap\u2a8a\u2a8d\u2a91r\xf2\u2971rr;\u61aear;\u6af2\u0180;sv\u0f8d\u2a9c\u0f8c\u0100;d\u2aa1\u2aa2\u62fc;\u62facy;\u445a\u0380AEadest\u2ab7\u2aba\u2abe\u2ac2\u2ac5\u2af6\u2af9r\xf2\u2966;\uc000\u2266\u0338rr;\u619ar;\u6025\u0200;fqs\u0c3b\u2ace\u2ae3\u2aeft\u0100ar\u2ad4\u2ad9rro\xf7\u2ac1ightarro\xf7\u2a90\u0180;qs\u0c3b\u2aba\u2aealan\xf4\u0c55\u0100;s\u0c55\u2af4\xbb\u0c36i\xed\u0c5d\u0100;r\u0c35\u2afei\u0100;e\u0c1a\u0c25i\xe4\u0d90\u0100pt\u2b0c\u2b11f;\uc000\ud835\udd5f\u8180\xac;in\u2b19\u2b1a\u2b36\u40acn\u0200;Edv\u0b89\u2b24\u2b28\u2b2e;\uc000\u22f9\u0338ot;\uc000\u22f5\u0338\u01e1\u0b89\u2b33\u2b35;\u62f7;\u62f6i\u0100;v\u0cb8\u2b3c\u01e1\u0cb8\u2b41\u2b43;\u62fe;\u62fd\u0180aor\u2b4b\u2b63\u2b69r\u0200;ast\u0b7b\u2b55\u2b5a\u2b5flle\xec\u0b7bl;\uc000\u2afd\u20e5;\uc000\u2202\u0338lint;\u6a14\u0180;ce\u0c92\u2b70\u2b73u\xe5\u0ca5\u0100;c\u0c98\u2b78\u0100;e\u0c92\u2b7d\xf1\u0c98\u0200Aait\u2b88\u2b8b\u2b9d\u2ba7r\xf2\u2988rr\u0180;cw\u2b94\u2b95\u2b99\u619b;\uc000\u2933\u0338;\uc000\u219d\u0338ghtarrow\xbb\u2b95ri\u0100;e\u0ccb\u0cd6\u0380chimpqu\u2bbd\u2bcd\u2bd9\u2b04\u0b78\u2be4\u2bef\u0200;cer\u0d32\u2bc6\u0d37\u2bc9u\xe5\u0d45;\uc000\ud835\udcc3ort\u026d\u2b05\0\0\u2bd6ar\xe1\u2b56m\u0100;e\u0d6e\u2bdf\u0100;q\u0d74\u0d73su\u0100bp\u2beb\u2bed\xe5\u0cf8\xe5\u0d0b\u0180bcp\u2bf6\u2c11\u2c19\u0200;Ees\u2bff\u2c00\u0d22\u2c04\u6284;\uc000\u2ac5\u0338et\u0100;e\u0d1b\u2c0bq\u0100;q\u0d23\u2c00c\u0100;e\u0d32\u2c17\xf1\u0d38\u0200;Ees\u2c22\u2c23\u0d5f\u2c27\u6285;\uc000\u2ac6\u0338et\u0100;e\u0d58\u2c2eq\u0100;q\u0d60\u2c23\u0200gilr\u2c3d\u2c3f\u2c45\u2c47\xec\u0bd7lde\u803b\xf1\u40f1\xe7\u0c43iangle\u0100lr\u2c52\u2c5ceft\u0100;e\u0c1a\u2c5a\xf1\u0c26ight\u0100;e\u0ccb\u2c65\xf1\u0cd7\u0100;m\u2c6c\u2c6d\u43bd\u0180;es\u2c74\u2c75\u2c79\u4023ro;\u6116p;\u6007\u0480DHadgilrs\u2c8f\u2c94\u2c99\u2c9e\u2ca3\u2cb0\u2cb6\u2cd3\u2ce3ash;\u62adarr;\u6904p;\uc000\u224d\u20d2ash;\u62ac\u0100et\u2ca8\u2cac;\uc000\u2265\u20d2;\uc000>\u20d2nfin;\u69de\u0180Aet\u2cbd\u2cc1\u2cc5rr;\u6902;\uc000\u2264\u20d2\u0100;r\u2cca\u2ccd\uc000<\u20d2ie;\uc000\u22b4\u20d2\u0100At\u2cd8\u2cdcrr;\u6903rie;\uc000\u22b5\u20d2im;\uc000\u223c\u20d2\u0180Aan\u2cf0\u2cf4\u2d02rr;\u61d6r\u0100hr\u2cfa\u2cfdk;\u6923\u0100;o\u13e7\u13e5ear;\u6927\u1253\u1a95\0\0\0\0\0\0\0\0\0\0\0\0\0\u2d2d\0\u2d38\u2d48\u2d60\u2d65\u2d72\u2d84\u1b07\0\0\u2d8d\u2dab\0\u2dc8\u2dce\0\u2ddc\u2e19\u2e2b\u2e3e\u2e43\u0100cs\u2d31\u1a97ute\u803b\xf3\u40f3\u0100iy\u2d3c\u2d45r\u0100;c\u1a9e\u2d42\u803b\xf4\u40f4;\u443e\u0280abios\u1aa0\u2d52\u2d57\u01c8\u2d5alac;\u4151v;\u6a38old;\u69bclig;\u4153\u0100cr\u2d69\u2d6dir;\u69bf;\uc000\ud835\udd2c\u036f\u2d79\0\0\u2d7c\0\u2d82n;\u42dbave\u803b\xf2\u40f2;\u69c1\u0100bm\u2d88\u0df4ar;\u69b5\u0200acit\u2d95\u2d98\u2da5\u2da8r\xf2\u1a80\u0100ir\u2d9d\u2da0r;\u69beoss;\u69bbn\xe5\u0e52;\u69c0\u0180aei\u2db1\u2db5\u2db9cr;\u414dga;\u43c9\u0180cdn\u2dc0\u2dc5\u01cdron;\u43bf;\u69b6pf;\uc000\ud835\udd60\u0180ael\u2dd4\u2dd7\u01d2r;\u69b7rp;\u69b9\u0380;adiosv\u2dea\u2deb\u2dee\u2e08\u2e0d\u2e10\u2e16\u6228r\xf2\u1a86\u0200;efm\u2df7\u2df8\u2e02\u2e05\u6a5dr\u0100;o\u2dfe\u2dff\u6134f\xbb\u2dff\u803b\xaa\u40aa\u803b\xba\u40bagof;\u62b6r;\u6a56lope;\u6a57;\u6a5b\u0180clo\u2e1f\u2e21\u2e27\xf2\u2e01ash\u803b\xf8\u40f8l;\u6298i\u016c\u2e2f\u2e34de\u803b\xf5\u40f5es\u0100;a\u01db\u2e3as;\u6a36ml\u803b\xf6\u40f6bar;\u633d\u0ae1\u2e5e\0\u2e7d\0\u2e80\u2e9d\0\u2ea2\u2eb9\0\0\u2ecb\u0e9c\0\u2f13\0\0\u2f2b\u2fbc\0\u2fc8r\u0200;ast\u0403\u2e67\u2e72\u0e85\u8100\xb6;l\u2e6d\u2e6e\u40b6le\xec\u0403\u0269\u2e78\0\0\u2e7bm;\u6af3;\u6afdy;\u443fr\u0280cimpt\u2e8b\u2e8f\u2e93\u1865\u2e97nt;\u4025od;\u402eil;\u6030enk;\u6031r;\uc000\ud835\udd2d\u0180imo\u2ea8\u2eb0\u2eb4\u0100;v\u2ead\u2eae\u43c6;\u43d5ma\xf4\u0a76ne;\u660e\u0180;tv\u2ebf\u2ec0\u2ec8\u43c0chfork\xbb\u1ffd;\u43d6\u0100au\u2ecf\u2edfn\u0100ck\u2ed5\u2eddk\u0100;h\u21f4\u2edb;\u610e\xf6\u21f4s\u0480;abcdemst\u2ef3\u2ef4\u1908\u2ef9\u2efd\u2f04\u2f06\u2f0a\u2f0e\u402bcir;\u6a23ir;\u6a22\u0100ou\u1d40\u2f02;\u6a25;\u6a72n\u80bb\xb1\u0e9dim;\u6a26wo;\u6a27\u0180ipu\u2f19\u2f20\u2f25ntint;\u6a15f;\uc000\ud835\udd61nd\u803b\xa3\u40a3\u0500;Eaceinosu\u0ec8\u2f3f\u2f41\u2f44\u2f47\u2f81\u2f89\u2f92\u2f7e\u2fb6;\u6ab3p;\u6ab7u\xe5\u0ed9\u0100;c\u0ece\u2f4c\u0300;acens\u0ec8\u2f59\u2f5f\u2f66\u2f68\u2f7eppro\xf8\u2f43urlye\xf1\u0ed9\xf1\u0ece\u0180aes\u2f6f\u2f76\u2f7approx;\u6ab9qq;\u6ab5im;\u62e8i\xed\u0edfme\u0100;s\u2f88\u0eae\u6032\u0180Eas\u2f78\u2f90\u2f7a\xf0\u2f75\u0180dfp\u0eec\u2f99\u2faf\u0180als\u2fa0\u2fa5\u2faalar;\u632eine;\u6312urf;\u6313\u0100;t\u0efb\u2fb4\xef\u0efbrel;\u62b0\u0100ci\u2fc0\u2fc5r;\uc000\ud835\udcc5;\u43c8ncsp;\u6008\u0300fiopsu\u2fda\u22e2\u2fdf\u2fe5\u2feb\u2ff1r;\uc000\ud835\udd2epf;\uc000\ud835\udd62rime;\u6057cr;\uc000\ud835\udcc6\u0180aeo\u2ff8\u3009\u3013t\u0100ei\u2ffe\u3005rnion\xf3\u06b0nt;\u6a16st\u0100;e\u3010\u3011\u403f\xf1\u1f19\xf4\u0f14\u0a80ABHabcdefhilmnoprstux\u3040\u3051\u3055\u3059\u30e0\u310e\u312b\u3147\u3162\u3172\u318e\u3206\u3215\u3224\u3229\u3258\u326e\u3272\u3290\u32b0\u32b7\u0180art\u3047\u304a\u304cr\xf2\u10b3\xf2\u03ddail;\u691car\xf2\u1c65ar;\u6964\u0380cdenqrt\u3068\u3075\u3078\u307f\u308f\u3094\u30cc\u0100eu\u306d\u3071;\uc000\u223d\u0331te;\u4155i\xe3\u116emptyv;\u69b3g\u0200;del\u0fd1\u3089\u308b\u308d;\u6992;\u69a5\xe5\u0fd1uo\u803b\xbb\u40bbr\u0580;abcfhlpstw\u0fdc\u30ac\u30af\u30b7\u30b9\u30bc\u30be\u30c0\u30c3\u30c7\u30cap;\u6975\u0100;f\u0fe0\u30b4s;\u6920;\u6933s;\u691e\xeb\u225d\xf0\u272el;\u6945im;\u6974l;\u61a3;\u619d\u0100ai\u30d1\u30d5il;\u691ao\u0100;n\u30db\u30dc\u6236al\xf3\u0f1e\u0180abr\u30e7\u30ea\u30eer\xf2\u17e5rk;\u6773\u0100ak\u30f3\u30fdc\u0100ek\u30f9\u30fb;\u407d;\u405d\u0100es\u3102\u3104;\u698cl\u0100du\u310a\u310c;\u698e;\u6990\u0200aeuy\u3117\u311c\u3127\u3129ron;\u4159\u0100di\u3121\u3125il;\u4157\xec\u0ff2\xe2\u30fa;\u4440\u0200clqs\u3134\u3137\u313d\u3144a;\u6937dhar;\u6969uo\u0100;r\u020e\u020dh;\u61b3\u0180acg\u314e\u315f\u0f44l\u0200;ips\u0f78\u3158\u315b\u109cn\xe5\u10bbar\xf4\u0fa9t;\u65ad\u0180ilr\u3169\u1023\u316esht;\u697d;\uc000\ud835\udd2f\u0100ao\u3177\u3186r\u0100du\u317d\u317f\xbb\u047b\u0100;l\u1091\u3184;\u696c\u0100;v\u318b\u318c\u43c1;\u43f1\u0180gns\u3195\u31f9\u31fcht\u0300ahlrst\u31a4\u31b0\u31c2\u31d8\u31e4\u31eerrow\u0100;t\u0fdc\u31ada\xe9\u30c8arpoon\u0100du\u31bb\u31bfow\xee\u317ep\xbb\u1092eft\u0100ah\u31ca\u31d0rrow\xf3\u0feaarpoon\xf3\u0551ightarrows;\u61c9quigarro\xf7\u30cbhreetimes;\u62ccg;\u42daingdotse\xf1\u1f32\u0180ahm\u320d\u3210\u3213r\xf2\u0feaa\xf2\u0551;\u600foust\u0100;a\u321e\u321f\u63b1che\xbb\u321fmid;\u6aee\u0200abpt\u3232\u323d\u3240\u3252\u0100nr\u3237\u323ag;\u67edr;\u61fer\xeb\u1003\u0180afl\u3247\u324a\u324er;\u6986;\uc000\ud835\udd63us;\u6a2eimes;\u6a35\u0100ap\u325d\u3267r\u0100;g\u3263\u3264\u4029t;\u6994olint;\u6a12ar\xf2\u31e3\u0200achq\u327b\u3280\u10bc\u3285quo;\u603ar;\uc000\ud835\udcc7\u0100bu\u30fb\u328ao\u0100;r\u0214\u0213\u0180hir\u3297\u329b\u32a0re\xe5\u31f8mes;\u62cai\u0200;efl\u32aa\u1059\u1821\u32ab\u65b9tri;\u69celuhar;\u6968;\u611e\u0d61\u32d5\u32db\u32df\u332c\u3338\u3371\0\u337a\u33a4\0\0\u33ec\u33f0\0\u3428\u3448\u345a\u34ad\u34b1\u34ca\u34f1\0\u3616\0\0\u3633cute;\u415bqu\xef\u27ba\u0500;Eaceinpsy\u11ed\u32f3\u32f5\u32ff\u3302\u330b\u330f\u331f\u3326\u3329;\u6ab4\u01f0\u32fa\0\u32fc;\u6ab8on;\u4161u\xe5\u11fe\u0100;d\u11f3\u3307il;\u415frc;\u415d\u0180Eas\u3316\u3318\u331b;\u6ab6p;\u6abaim;\u62e9olint;\u6a13i\xed\u1204;\u4441ot\u0180;be\u3334\u1d47\u3335\u62c5;\u6a66\u0380Aacmstx\u3346\u334a\u3357\u335b\u335e\u3363\u336drr;\u61d8r\u0100hr\u3350\u3352\xeb\u2228\u0100;o\u0a36\u0a34t\u803b\xa7\u40a7i;\u403bwar;\u6929m\u0100in\u3369\xf0nu\xf3\xf1t;\u6736r\u0100;o\u3376\u2055\uc000\ud835\udd30\u0200acoy\u3382\u3386\u3391\u33a0rp;\u666f\u0100hy\u338b\u338fcy;\u4449;\u4448rt\u026d\u3399\0\0\u339ci\xe4\u1464ara\xec\u2e6f\u803b\xad\u40ad\u0100gm\u33a8\u33b4ma\u0180;fv\u33b1\u33b2\u33b2\u43c3;\u43c2\u0400;deglnpr\u12ab\u33c5\u33c9\u33ce\u33d6\u33de\u33e1\u33e6ot;\u6a6a\u0100;q\u12b1\u12b0\u0100;E\u33d3\u33d4\u6a9e;\u6aa0\u0100;E\u33db\u33dc\u6a9d;\u6a9fe;\u6246lus;\u6a24arr;\u6972ar\xf2\u113d\u0200aeit\u33f8\u3408\u340f\u3417\u0100ls\u33fd\u3404lsetm\xe9\u336ahp;\u6a33parsl;\u69e4\u0100dl\u1463\u3414e;\u6323\u0100;e\u341c\u341d\u6aaa\u0100;s\u3422\u3423\u6aac;\uc000\u2aac\ufe00\u0180flp\u342e\u3433\u3442tcy;\u444c\u0100;b\u3438\u3439\u402f\u0100;a\u343e\u343f\u69c4r;\u633ff;\uc000\ud835\udd64a\u0100dr\u344d\u0402es\u0100;u\u3454\u3455\u6660it\xbb\u3455\u0180csu\u3460\u3479\u349f\u0100au\u3465\u346fp\u0100;s\u1188\u346b;\uc000\u2293\ufe00p\u0100;s\u11b4\u3475;\uc000\u2294\ufe00u\u0100bp\u347f\u348f\u0180;es\u1197\u119c\u3486et\u0100;e\u1197\u348d\xf1\u119d\u0180;es\u11a8\u11ad\u3496et\u0100;e\u11a8\u349d\xf1\u11ae\u0180;af\u117b\u34a6\u05b0r\u0165\u34ab\u05b1\xbb\u117car\xf2\u1148\u0200cemt\u34b9\u34be\u34c2\u34c5r;\uc000\ud835\udcc8tm\xee\xf1i\xec\u3415ar\xe6\u11be\u0100ar\u34ce\u34d5r\u0100;f\u34d4\u17bf\u6606\u0100an\u34da\u34edight\u0100ep\u34e3\u34eapsilo\xee\u1ee0h\xe9\u2eafs\xbb\u2852\u0280bcmnp\u34fb\u355e\u1209\u358b\u358e\u0480;Edemnprs\u350e\u350f\u3511\u3515\u351e\u3523\u352c\u3531\u3536\u6282;\u6ac5ot;\u6abd\u0100;d\u11da\u351aot;\u6ac3ult;\u6ac1\u0100Ee\u3528\u352a;\u6acb;\u628alus;\u6abfarr;\u6979\u0180eiu\u353d\u3552\u3555t\u0180;en\u350e\u3545\u354bq\u0100;q\u11da\u350feq\u0100;q\u352b\u3528m;\u6ac7\u0100bp\u355a\u355c;\u6ad5;\u6ad3c\u0300;acens\u11ed\u356c\u3572\u3579\u357b\u3326ppro\xf8\u32faurlye\xf1\u11fe\xf1\u11f3\u0180aes\u3582\u3588\u331bppro\xf8\u331aq\xf1\u3317g;\u666a\u0680123;Edehlmnps\u35a9\u35ac\u35af\u121c\u35b2\u35b4\u35c0\u35c9\u35d5\u35da\u35df\u35e8\u35ed\u803b\xb9\u40b9\u803b\xb2\u40b2\u803b\xb3\u40b3;\u6ac6\u0100os\u35b9\u35bct;\u6abeub;\u6ad8\u0100;d\u1222\u35c5ot;\u6ac4s\u0100ou\u35cf\u35d2l;\u67c9b;\u6ad7arr;\u697bult;\u6ac2\u0100Ee\u35e4\u35e6;\u6acc;\u628blus;\u6ac0\u0180eiu\u35f4\u3609\u360ct\u0180;en\u121c\u35fc\u3602q\u0100;q\u1222\u35b2eq\u0100;q\u35e7\u35e4m;\u6ac8\u0100bp\u3611\u3613;\u6ad4;\u6ad6\u0180Aan\u361c\u3620\u362drr;\u61d9r\u0100hr\u3626\u3628\xeb\u222e\u0100;o\u0a2b\u0a29war;\u692alig\u803b\xdf\u40df\u0be1\u3651\u365d\u3660\u12ce\u3673\u3679\0\u367e\u36c2\0\0\0\0\0\u36db\u3703\0\u3709\u376c\0\0\0\u3787\u0272\u3656\0\0\u365bget;\u6316;\u43c4r\xeb\u0e5f\u0180aey\u3666\u366b\u3670ron;\u4165dil;\u4163;\u4442lrec;\u6315r;\uc000\ud835\udd31\u0200eiko\u3686\u369d\u36b5\u36bc\u01f2\u368b\0\u3691e\u01004f\u1284\u1281a\u0180;sv\u3698\u3699\u369b\u43b8ym;\u43d1\u0100cn\u36a2\u36b2k\u0100as\u36a8\u36aeppro\xf8\u12c1im\xbb\u12acs\xf0\u129e\u0100as\u36ba\u36ae\xf0\u12c1rn\u803b\xfe\u40fe\u01ec\u031f\u36c6\u22e7es\u8180\xd7;bd\u36cf\u36d0\u36d8\u40d7\u0100;a\u190f\u36d5r;\u6a31;\u6a30\u0180eps\u36e1\u36e3\u3700\xe1\u2a4d\u0200;bcf\u0486\u36ec\u36f0\u36f4ot;\u6336ir;\u6af1\u0100;o\u36f9\u36fc\uc000\ud835\udd65rk;\u6ada\xe1\u3362rime;\u6034\u0180aip\u370f\u3712\u3764d\xe5\u1248\u0380adempst\u3721\u374d\u3740\u3751\u3757\u375c\u375fngle\u0280;dlqr\u3730\u3731\u3736\u3740\u3742\u65b5own\xbb\u1dbbeft\u0100;e\u2800\u373e\xf1\u092e;\u625cight\u0100;e\u32aa\u374b\xf1\u105aot;\u65ecinus;\u6a3alus;\u6a39b;\u69cdime;\u6a3bezium;\u63e2\u0180cht\u3772\u377d\u3781\u0100ry\u3777\u377b;\uc000\ud835\udcc9;\u4446cy;\u445brok;\u4167\u0100io\u378b\u378ex\xf4\u1777head\u0100lr\u3797\u37a0eftarro\xf7\u084fightarrow\xbb\u0f5d\u0900AHabcdfghlmoprstuw\u37d0\u37d3\u37d7\u37e4\u37f0\u37fc\u380e\u381c\u3823\u3834\u3851\u385d\u386b\u38a9\u38cc\u38d2\u38ea\u38f6r\xf2\u03edar;\u6963\u0100cr\u37dc\u37e2ute\u803b\xfa\u40fa\xf2\u1150r\u01e3\u37ea\0\u37edy;\u445eve;\u416d\u0100iy\u37f5\u37farc\u803b\xfb\u40fb;\u4443\u0180abh\u3803\u3806\u380br\xf2\u13adlac;\u4171a\xf2\u13c3\u0100ir\u3813\u3818sht;\u697e;\uc000\ud835\udd32rave\u803b\xf9\u40f9\u0161\u3827\u3831r\u0100lr\u382c\u382e\xbb\u0957\xbb\u1083lk;\u6580\u0100ct\u3839\u384d\u026f\u383f\0\0\u384arn\u0100;e\u3845\u3846\u631cr\xbb\u3846op;\u630fri;\u65f8\u0100al\u3856\u385acr;\u416b\u80bb\xa8\u0349\u0100gp\u3862\u3866on;\u4173f;\uc000\ud835\udd66\u0300adhlsu\u114b\u3878\u387d\u1372\u3891\u38a0own\xe1\u13b3arpoon\u0100lr\u3888\u388cef\xf4\u382digh\xf4\u382fi\u0180;hl\u3899\u389a\u389c\u43c5\xbb\u13faon\xbb\u389aparrows;\u61c8\u0180cit\u38b0\u38c4\u38c8\u026f\u38b6\0\0\u38c1rn\u0100;e\u38bc\u38bd\u631dr\xbb\u38bdop;\u630eng;\u416fri;\u65f9cr;\uc000\ud835\udcca\u0180dir\u38d9\u38dd\u38e2ot;\u62f0lde;\u4169i\u0100;f\u3730\u38e8\xbb\u1813\u0100am\u38ef\u38f2r\xf2\u38a8l\u803b\xfc\u40fcangle;\u69a7\u0780ABDacdeflnoprsz\u391c\u391f\u3929\u392d\u39b5\u39b8\u39bd\u39df\u39e4\u39e8\u39f3\u39f9\u39fd\u3a01\u3a20r\xf2\u03f7ar\u0100;v\u3926\u3927\u6ae8;\u6ae9as\xe8\u03e1\u0100nr\u3932\u3937grt;\u699c\u0380eknprst\u34e3\u3946\u394b\u3952\u395d\u3964\u3996app\xe1\u2415othin\xe7\u1e96\u0180hir\u34eb\u2ec8\u3959op\xf4\u2fb5\u0100;h\u13b7\u3962\xef\u318d\u0100iu\u3969\u396dgm\xe1\u33b3\u0100bp\u3972\u3984setneq\u0100;q\u397d\u3980\uc000\u228a\ufe00;\uc000\u2acb\ufe00setneq\u0100;q\u398f\u3992\uc000\u228b\ufe00;\uc000\u2acc\ufe00\u0100hr\u399b\u399fet\xe1\u369ciangle\u0100lr\u39aa\u39afeft\xbb\u0925ight\xbb\u1051y;\u4432ash\xbb\u1036\u0180elr\u39c4\u39d2\u39d7\u0180;be\u2dea\u39cb\u39cfar;\u62bbq;\u625alip;\u62ee\u0100bt\u39dc\u1468a\xf2\u1469r;\uc000\ud835\udd33tr\xe9\u39aesu\u0100bp\u39ef\u39f1\xbb\u0d1c\xbb\u0d59pf;\uc000\ud835\udd67ro\xf0\u0efbtr\xe9\u39b4\u0100cu\u3a06\u3a0br;\uc000\ud835\udccb\u0100bp\u3a10\u3a18n\u0100Ee\u3980\u3a16\xbb\u397en\u0100Ee\u3992\u3a1e\xbb\u3990igzag;\u699a\u0380cefoprs\u3a36\u3a3b\u3a56\u3a5b\u3a54\u3a61\u3a6airc;\u4175\u0100di\u3a40\u3a51\u0100bg\u3a45\u3a49ar;\u6a5fe\u0100;q\u15fa\u3a4f;\u6259erp;\u6118r;\uc000\ud835\udd34pf;\uc000\ud835\udd68\u0100;e\u1479\u3a66at\xe8\u1479cr;\uc000\ud835\udccc\u0ae3\u178e\u3a87\0\u3a8b\0\u3a90\u3a9b\0\0\u3a9d\u3aa8\u3aab\u3aaf\0\0\u3ac3\u3ace\0\u3ad8\u17dc\u17dftr\xe9\u17d1r;\uc000\ud835\udd35\u0100Aa\u3a94\u3a97r\xf2\u03c3r\xf2\u09f6;\u43be\u0100Aa\u3aa1\u3aa4r\xf2\u03b8r\xf2\u09eba\xf0\u2713is;\u62fb\u0180dpt\u17a4\u3ab5\u3abe\u0100fl\u3aba\u17a9;\uc000\ud835\udd69im\xe5\u17b2\u0100Aa\u3ac7\u3acar\xf2\u03cer\xf2\u0a01\u0100cq\u3ad2\u17b8r;\uc000\ud835\udccd\u0100pt\u17d6\u3adcr\xe9\u17d4\u0400acefiosu\u3af0\u3afd\u3b08\u3b0c\u3b11\u3b15\u3b1b\u3b21c\u0100uy\u3af6\u3afbte\u803b\xfd\u40fd;\u444f\u0100iy\u3b02\u3b06rc;\u4177;\u444bn\u803b\xa5\u40a5r;\uc000\ud835\udd36cy;\u4457pf;\uc000\ud835\udd6acr;\uc000\ud835\udcce\u0100cm\u3b26\u3b29y;\u444el\u803b\xff\u40ff\u0500acdefhiosw\u3b42\u3b48\u3b54\u3b58\u3b64\u3b69\u3b6d\u3b74\u3b7a\u3b80cute;\u417a\u0100ay\u3b4d\u3b52ron;\u417e;\u4437ot;\u417c\u0100et\u3b5d\u3b61tr\xe6\u155fa;\u43b6r;\uc000\ud835\udd37cy;\u4436grarr;\u61ddpf;\uc000\ud835\udd6bcr;\uc000\ud835\udccf\u0100jn\u3b85\u3b87;\u600dj;\u600c"
+    .split("")
+    .map((c) => c.charCodeAt(0))));
+//# sourceMappingURL=decode-data-html.js.map
+;// CONCATENATED MODULE: ./node_modules/entities/lib/esm/generated/decode-data-xml.js
+// Generated using scripts/write-decode-map.ts
+/* harmony default export */ const decode_data_xml = (new Uint16Array(
+// prettier-ignore
+"\u0200aglq\t\x15\x18\x1b\u026d\x0f\0\0\x12p;\u4026os;\u4027t;\u403et;\u403cuot;\u4022"
+    .split("")
+    .map((c) => c.charCodeAt(0))));
+//# sourceMappingURL=decode-data-xml.js.map
+;// CONCATENATED MODULE: ./node_modules/entities/lib/esm/decode_codepoint.js
+// Adapted from https://github.com/mathiasbynens/he/blob/36afe179392226cf1b6ccdb16ebbb7a5a844d93a/src/he.js#L106-L134
+var _a;
+const decodeMap = new Map([
+    [0, 65533],
+    // C1 Unicode control character reference replacements
+    [128, 8364],
+    [130, 8218],
+    [131, 402],
+    [132, 8222],
+    [133, 8230],
+    [134, 8224],
+    [135, 8225],
+    [136, 710],
+    [137, 8240],
+    [138, 352],
+    [139, 8249],
+    [140, 338],
+    [142, 381],
+    [145, 8216],
+    [146, 8217],
+    [147, 8220],
+    [148, 8221],
+    [149, 8226],
+    [150, 8211],
+    [151, 8212],
+    [152, 732],
+    [153, 8482],
+    [154, 353],
+    [155, 8250],
+    [156, 339],
+    [158, 382],
+    [159, 376],
+]);
+/**
+ * Polyfill for `String.fromCodePoint`. It is used to create a string from a Unicode code point.
+ */
+const fromCodePoint = 
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, node/no-unsupported-features/es-builtins
+(_a = String.fromCodePoint) !== null && _a !== void 0 ? _a : function (codePoint) {
+    let output = "";
+    if (codePoint > 0xffff) {
+        codePoint -= 0x10000;
+        output += String.fromCharCode(((codePoint >>> 10) & 0x3ff) | 0xd800);
+        codePoint = 0xdc00 | (codePoint & 0x3ff);
+    }
+    output += String.fromCharCode(codePoint);
+    return output;
+};
+/**
+ * Replace the given code point with a replacement character if it is a
+ * surrogate or is outside the valid range. Otherwise return the code
+ * point unchanged.
+ */
+function replaceCodePoint(codePoint) {
+    var _a;
+    if ((codePoint >= 0xd800 && codePoint <= 0xdfff) || codePoint > 0x10ffff) {
+        return 0xfffd;
+    }
+    return (_a = decodeMap.get(codePoint)) !== null && _a !== void 0 ? _a : codePoint;
+}
+/**
+ * Replace the code point if relevant, then convert it to a string.
+ *
+ * @deprecated Use `fromCodePoint(replaceCodePoint(codePoint))` instead.
+ * @param codePoint The code point to decode.
+ * @returns The decoded code point.
+ */
+function decodeCodePoint(codePoint) {
+    return fromCodePoint(replaceCodePoint(codePoint));
+}
+//# sourceMappingURL=decode_codepoint.js.map
+;// CONCATENATED MODULE: ./node_modules/entities/lib/esm/decode.js
+
+
+
+// Re-export for use by eg. htmlparser2
+
+
+var CharCodes;
+(function (CharCodes) {
+    CharCodes[CharCodes["NUM"] = 35] = "NUM";
+    CharCodes[CharCodes["SEMI"] = 59] = "SEMI";
+    CharCodes[CharCodes["EQUALS"] = 61] = "EQUALS";
+    CharCodes[CharCodes["ZERO"] = 48] = "ZERO";
+    CharCodes[CharCodes["NINE"] = 57] = "NINE";
+    CharCodes[CharCodes["LOWER_A"] = 97] = "LOWER_A";
+    CharCodes[CharCodes["LOWER_F"] = 102] = "LOWER_F";
+    CharCodes[CharCodes["LOWER_X"] = 120] = "LOWER_X";
+    CharCodes[CharCodes["LOWER_Z"] = 122] = "LOWER_Z";
+    CharCodes[CharCodes["UPPER_A"] = 65] = "UPPER_A";
+    CharCodes[CharCodes["UPPER_F"] = 70] = "UPPER_F";
+    CharCodes[CharCodes["UPPER_Z"] = 90] = "UPPER_Z";
+})(CharCodes || (CharCodes = {}));
+/** Bit that needs to be set to convert an upper case ASCII character to lower case */
+const TO_LOWER_BIT = 0b100000;
+var BinTrieFlags;
+(function (BinTrieFlags) {
+    BinTrieFlags[BinTrieFlags["VALUE_LENGTH"] = 49152] = "VALUE_LENGTH";
+    BinTrieFlags[BinTrieFlags["BRANCH_LENGTH"] = 16256] = "BRANCH_LENGTH";
+    BinTrieFlags[BinTrieFlags["JUMP_TABLE"] = 127] = "JUMP_TABLE";
+})(BinTrieFlags || (BinTrieFlags = {}));
+function isNumber(code) {
+    return code >= CharCodes.ZERO && code <= CharCodes.NINE;
+}
+function isHexadecimalCharacter(code) {
+    return ((code >= CharCodes.UPPER_A && code <= CharCodes.UPPER_F) ||
+        (code >= CharCodes.LOWER_A && code <= CharCodes.LOWER_F));
+}
+function isAsciiAlphaNumeric(code) {
+    return ((code >= CharCodes.UPPER_A && code <= CharCodes.UPPER_Z) ||
+        (code >= CharCodes.LOWER_A && code <= CharCodes.LOWER_Z) ||
+        isNumber(code));
+}
+/**
+ * Checks if the given character is a valid end character for an entity in an attribute.
+ *
+ * Attribute values that aren't terminated properly aren't parsed, and shouldn't lead to a parser error.
+ * See the example in https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state
+ */
+function isEntityInAttributeInvalidEnd(code) {
+    return code === CharCodes.EQUALS || isAsciiAlphaNumeric(code);
+}
+var EntityDecoderState;
+(function (EntityDecoderState) {
+    EntityDecoderState[EntityDecoderState["EntityStart"] = 0] = "EntityStart";
+    EntityDecoderState[EntityDecoderState["NumericStart"] = 1] = "NumericStart";
+    EntityDecoderState[EntityDecoderState["NumericDecimal"] = 2] = "NumericDecimal";
+    EntityDecoderState[EntityDecoderState["NumericHex"] = 3] = "NumericHex";
+    EntityDecoderState[EntityDecoderState["NamedEntity"] = 4] = "NamedEntity";
+})(EntityDecoderState || (EntityDecoderState = {}));
+var DecodingMode;
+(function (DecodingMode) {
+    /** Entities in text nodes that can end with any character. */
+    DecodingMode[DecodingMode["Legacy"] = 0] = "Legacy";
+    /** Only allow entities terminated with a semicolon. */
+    DecodingMode[DecodingMode["Strict"] = 1] = "Strict";
+    /** Entities in attributes have limitations on ending characters. */
+    DecodingMode[DecodingMode["Attribute"] = 2] = "Attribute";
+})(DecodingMode || (DecodingMode = {}));
+/**
+ * Token decoder with support of writing partial entities.
+ */
+class EntityDecoder {
+    constructor(
+    /** The tree used to decode entities. */
+    decodeTree, 
+    /**
+     * The function that is called when a codepoint is decoded.
+     *
+     * For multi-byte named entities, this will be called multiple times,
+     * with the second codepoint, and the same `consumed` value.
+     *
+     * @param codepoint The decoded codepoint.
+     * @param consumed The number of bytes consumed by the decoder.
+     */
+    emitCodePoint, 
+    /** An object that is used to produce errors. */
+    errors) {
+        this.decodeTree = decodeTree;
+        this.emitCodePoint = emitCodePoint;
+        this.errors = errors;
+        /** The current state of the decoder. */
+        this.state = EntityDecoderState.EntityStart;
+        /** Characters that were consumed while parsing an entity. */
+        this.consumed = 1;
+        /**
+         * The result of the entity.
+         *
+         * Either the result index of a numeric entity, or the codepoint of a
+         * numeric entity.
+         */
+        this.result = 0;
+        /** The current index in the decode tree. */
+        this.treeIndex = 0;
+        /** The number of characters that were consumed in excess. */
+        this.excess = 1;
+        /** The mode in which the decoder is operating. */
+        this.decodeMode = DecodingMode.Strict;
+    }
+    /** Resets the instance to make it reusable. */
+    startEntity(decodeMode) {
+        this.decodeMode = decodeMode;
+        this.state = EntityDecoderState.EntityStart;
+        this.result = 0;
+        this.treeIndex = 0;
+        this.excess = 1;
+        this.consumed = 1;
+    }
+    /**
+     * Write an entity to the decoder. This can be called multiple times with partial entities.
+     * If the entity is incomplete, the decoder will return -1.
+     *
+     * Mirrors the implementation of `getDecoder`, but with the ability to stop decoding if the
+     * entity is incomplete, and resume when the next string is written.
+     *
+     * @param string The string containing the entity (or a continuation of the entity).
+     * @param offset The offset at which the entity begins. Should be 0 if this is not the first call.
+     * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+     */
+    write(str, offset) {
+        switch (this.state) {
+            case EntityDecoderState.EntityStart: {
+                if (str.charCodeAt(offset) === CharCodes.NUM) {
+                    this.state = EntityDecoderState.NumericStart;
+                    this.consumed += 1;
+                    return this.stateNumericStart(str, offset + 1);
+                }
+                this.state = EntityDecoderState.NamedEntity;
+                return this.stateNamedEntity(str, offset);
+            }
+            case EntityDecoderState.NumericStart: {
+                return this.stateNumericStart(str, offset);
+            }
+            case EntityDecoderState.NumericDecimal: {
+                return this.stateNumericDecimal(str, offset);
+            }
+            case EntityDecoderState.NumericHex: {
+                return this.stateNumericHex(str, offset);
+            }
+            case EntityDecoderState.NamedEntity: {
+                return this.stateNamedEntity(str, offset);
+            }
+        }
+    }
+    /**
+     * Switches between the numeric decimal and hexadecimal states.
+     *
+     * Equivalent to the `Numeric character reference state` in the HTML spec.
+     *
+     * @param str The string containing the entity (or a continuation of the entity).
+     * @param offset The current offset.
+     * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+     */
+    stateNumericStart(str, offset) {
+        if (offset >= str.length) {
+            return -1;
+        }
+        if ((str.charCodeAt(offset) | TO_LOWER_BIT) === CharCodes.LOWER_X) {
+            this.state = EntityDecoderState.NumericHex;
+            this.consumed += 1;
+            return this.stateNumericHex(str, offset + 1);
+        }
+        this.state = EntityDecoderState.NumericDecimal;
+        return this.stateNumericDecimal(str, offset);
+    }
+    addToNumericResult(str, start, end, base) {
+        if (start !== end) {
+            const digitCount = end - start;
+            this.result =
+                this.result * Math.pow(base, digitCount) +
+                    parseInt(str.substr(start, digitCount), base);
+            this.consumed += digitCount;
+        }
+    }
+    /**
+     * Parses a hexadecimal numeric entity.
+     *
+     * Equivalent to the `Hexademical character reference state` in the HTML spec.
+     *
+     * @param str The string containing the entity (or a continuation of the entity).
+     * @param offset The current offset.
+     * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+     */
+    stateNumericHex(str, offset) {
+        const startIdx = offset;
+        while (offset < str.length) {
+            const char = str.charCodeAt(offset);
+            if (isNumber(char) || isHexadecimalCharacter(char)) {
+                offset += 1;
+            }
+            else {
+                this.addToNumericResult(str, startIdx, offset, 16);
+                return this.emitNumericEntity(char, 3);
+            }
+        }
+        this.addToNumericResult(str, startIdx, offset, 16);
+        return -1;
+    }
+    /**
+     * Parses a decimal numeric entity.
+     *
+     * Equivalent to the `Decimal character reference state` in the HTML spec.
+     *
+     * @param str The string containing the entity (or a continuation of the entity).
+     * @param offset The current offset.
+     * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+     */
+    stateNumericDecimal(str, offset) {
+        const startIdx = offset;
+        while (offset < str.length) {
+            const char = str.charCodeAt(offset);
+            if (isNumber(char)) {
+                offset += 1;
+            }
+            else {
+                this.addToNumericResult(str, startIdx, offset, 10);
+                return this.emitNumericEntity(char, 2);
+            }
+        }
+        this.addToNumericResult(str, startIdx, offset, 10);
+        return -1;
+    }
+    /**
+     * Validate and emit a numeric entity.
+     *
+     * Implements the logic from the `Hexademical character reference start
+     * state` and `Numeric character reference end state` in the HTML spec.
+     *
+     * @param lastCp The last code point of the entity. Used to see if the
+     *               entity was terminated with a semicolon.
+     * @param expectedLength The minimum number of characters that should be
+     *                       consumed. Used to validate that at least one digit
+     *                       was consumed.
+     * @returns The number of characters that were consumed.
+     */
+    emitNumericEntity(lastCp, expectedLength) {
+        var _a;
+        // Ensure we consumed at least one digit.
+        if (this.consumed <= expectedLength) {
+            (_a = this.errors) === null || _a === void 0 ? void 0 : _a.absenceOfDigitsInNumericCharacterReference(this.consumed);
+            return 0;
+        }
+        // Figure out if this is a legit end of the entity
+        if (lastCp === CharCodes.SEMI) {
+            this.consumed += 1;
+        }
+        else if (this.decodeMode === DecodingMode.Strict) {
+            return 0;
+        }
+        this.emitCodePoint(replaceCodePoint(this.result), this.consumed);
+        if (this.errors) {
+            if (lastCp !== CharCodes.SEMI) {
+                this.errors.missingSemicolonAfterCharacterReference();
+            }
+            this.errors.validateNumericCharacterReference(this.result);
+        }
+        return this.consumed;
+    }
+    /**
+     * Parses a named entity.
+     *
+     * Equivalent to the `Named character reference state` in the HTML spec.
+     *
+     * @param str The string containing the entity (or a continuation of the entity).
+     * @param offset The current offset.
+     * @returns The number of characters that were consumed, or -1 if the entity is incomplete.
+     */
+    stateNamedEntity(str, offset) {
+        const { decodeTree } = this;
+        let current = decodeTree[this.treeIndex];
+        // The mask is the number of bytes of the value, including the current byte.
+        let valueLength = (current & BinTrieFlags.VALUE_LENGTH) >> 14;
+        for (; offset < str.length; offset++, this.excess++) {
+            const char = str.charCodeAt(offset);
+            this.treeIndex = determineBranch(decodeTree, current, this.treeIndex + Math.max(1, valueLength), char);
+            if (this.treeIndex < 0) {
+                return this.result === 0 ||
+                    // If we are parsing an attribute
+                    (this.decodeMode === DecodingMode.Attribute &&
+                        // We shouldn't have consumed any characters after the entity,
+                        (valueLength === 0 ||
+                            // And there should be no invalid characters.
+                            isEntityInAttributeInvalidEnd(char)))
+                    ? 0
+                    : this.emitNotTerminatedNamedEntity();
+            }
+            current = decodeTree[this.treeIndex];
+            valueLength = (current & BinTrieFlags.VALUE_LENGTH) >> 14;
+            // If the branch is a value, store it and continue
+            if (valueLength !== 0) {
+                // If the entity is terminated by a semicolon, we are done.
+                if (char === CharCodes.SEMI) {
+                    return this.emitNamedEntityData(this.treeIndex, valueLength, this.consumed + this.excess);
+                }
+                // If we encounter a non-terminated (legacy) entity while parsing strictly, then ignore it.
+                if (this.decodeMode !== DecodingMode.Strict) {
+                    this.result = this.treeIndex;
+                    this.consumed += this.excess;
+                    this.excess = 0;
+                }
+            }
+        }
+        return -1;
+    }
+    /**
+     * Emit a named entity that was not terminated with a semicolon.
+     *
+     * @returns The number of characters consumed.
+     */
+    emitNotTerminatedNamedEntity() {
+        var _a;
+        const { result, decodeTree } = this;
+        const valueLength = (decodeTree[result] & BinTrieFlags.VALUE_LENGTH) >> 14;
+        this.emitNamedEntityData(result, valueLength, this.consumed);
+        (_a = this.errors) === null || _a === void 0 ? void 0 : _a.missingSemicolonAfterCharacterReference();
+        return this.consumed;
+    }
+    /**
+     * Emit a named entity.
+     *
+     * @param result The index of the entity in the decode tree.
+     * @param valueLength The number of bytes in the entity.
+     * @param consumed The number of characters consumed.
+     *
+     * @returns The number of characters consumed.
+     */
+    emitNamedEntityData(result, valueLength, consumed) {
+        const { decodeTree } = this;
+        this.emitCodePoint(valueLength === 1
+            ? decodeTree[result] & ~BinTrieFlags.VALUE_LENGTH
+            : decodeTree[result + 1], consumed);
+        if (valueLength === 3) {
+            // For multi-byte values, we need to emit the second byte.
+            this.emitCodePoint(decodeTree[result + 2], consumed);
+        }
+        return consumed;
+    }
+    /**
+     * Signal to the parser that the end of the input was reached.
+     *
+     * Remaining data will be emitted and relevant errors will be produced.
+     *
+     * @returns The number of characters consumed.
+     */
+    end() {
+        var _a;
+        switch (this.state) {
+            case EntityDecoderState.NamedEntity: {
+                // Emit a named entity if we have one.
+                return this.result !== 0 &&
+                    (this.decodeMode !== DecodingMode.Attribute ||
+                        this.result === this.treeIndex)
+                    ? this.emitNotTerminatedNamedEntity()
+                    : 0;
+            }
+            // Otherwise, emit a numeric entity if we have one.
+            case EntityDecoderState.NumericDecimal: {
+                return this.emitNumericEntity(0, 2);
+            }
+            case EntityDecoderState.NumericHex: {
+                return this.emitNumericEntity(0, 3);
+            }
+            case EntityDecoderState.NumericStart: {
+                (_a = this.errors) === null || _a === void 0 ? void 0 : _a.absenceOfDigitsInNumericCharacterReference(this.consumed);
+                return 0;
+            }
+            case EntityDecoderState.EntityStart: {
+                // Return 0 if we have no entity.
+                return 0;
+            }
+        }
+    }
+}
+/**
+ * Creates a function that decodes entities in a string.
+ *
+ * @param decodeTree The decode tree.
+ * @returns A function that decodes entities in a string.
+ */
+function getDecoder(decodeTree) {
+    let ret = "";
+    const decoder = new EntityDecoder(decodeTree, (str) => (ret += fromCodePoint(str)));
+    return function decodeWithTrie(str, decodeMode) {
+        let lastIndex = 0;
+        let offset = 0;
+        while ((offset = str.indexOf("&", offset)) >= 0) {
+            ret += str.slice(lastIndex, offset);
+            decoder.startEntity(decodeMode);
+            const len = decoder.write(str, 
+            // Skip the "&"
+            offset + 1);
+            if (len < 0) {
+                lastIndex = offset + decoder.end();
+                break;
+            }
+            lastIndex = offset + len;
+            // If `len` is 0, skip the current `&` and continue.
+            offset = len === 0 ? lastIndex + 1 : lastIndex;
+        }
+        const result = ret + str.slice(lastIndex);
+        // Make sure we don't keep a reference to the final string.
+        ret = "";
+        return result;
+    };
+}
+/**
+ * Determines the branch of the current node that is taken given the current
+ * character. This function is used to traverse the trie.
+ *
+ * @param decodeTree The trie.
+ * @param current The current node.
+ * @param nodeIdx The index right after the current node and its value.
+ * @param char The current character.
+ * @returns The index of the next node, or -1 if no branch is taken.
+ */
+function determineBranch(decodeTree, current, nodeIdx, char) {
+    const branchCount = (current & BinTrieFlags.BRANCH_LENGTH) >> 7;
+    const jumpOffset = current & BinTrieFlags.JUMP_TABLE;
+    // Case 1: Single branch encoded in jump offset
+    if (branchCount === 0) {
+        return jumpOffset !== 0 && char === jumpOffset ? nodeIdx : -1;
+    }
+    // Case 2: Multiple branches encoded in jump table
+    if (jumpOffset) {
+        const value = char - jumpOffset;
+        return value < 0 || value >= branchCount
+            ? -1
+            : decodeTree[nodeIdx + value] - 1;
+    }
+    // Case 3: Multiple branches encoded in dictionary
+    // Binary search for the character.
+    let lo = nodeIdx;
+    let hi = lo + branchCount - 1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >>> 1;
+        const midVal = decodeTree[mid];
+        if (midVal < char) {
+            lo = mid + 1;
+        }
+        else if (midVal > char) {
+            hi = mid - 1;
+        }
+        else {
+            return decodeTree[mid + branchCount];
+        }
+    }
+    return -1;
+}
+const htmlDecoder = getDecoder(decode_data_html);
+const xmlDecoder = getDecoder(decode_data_xml);
+/**
+ * Decodes an HTML string.
+ *
+ * @param str The string to decode.
+ * @param mode The decoding mode.
+ * @returns The decoded string.
+ */
+function decodeHTML(str, mode = DecodingMode.Legacy) {
+    return htmlDecoder(str, mode);
+}
+/**
+ * Decodes an HTML string in an attribute.
+ *
+ * @param str The string to decode.
+ * @returns The decoded string.
+ */
+function decodeHTMLAttribute(str) {
+    return htmlDecoder(str, DecodingMode.Attribute);
+}
+/**
+ * Decodes an HTML string, requiring all entities to be terminated by a semicolon.
+ *
+ * @param str The string to decode.
+ * @returns The decoded string.
+ */
+function decodeHTMLStrict(str) {
+    return htmlDecoder(str, DecodingMode.Strict);
+}
+/**
+ * Decodes an XML string, requiring all entities to be terminated by a semicolon.
+ *
+ * @param str The string to decode.
+ * @returns The decoded string.
+ */
+function decodeXML(str) {
+    return xmlDecoder(str, DecodingMode.Strict);
+}
+//# sourceMappingURL=decode.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/common/html.js
+/** All valid namespaces in HTML. */
+var html_NS;
+(function (NS) {
+    NS["HTML"] = "http://www.w3.org/1999/xhtml";
+    NS["MATHML"] = "http://www.w3.org/1998/Math/MathML";
+    NS["SVG"] = "http://www.w3.org/2000/svg";
+    NS["XLINK"] = "http://www.w3.org/1999/xlink";
+    NS["XML"] = "http://www.w3.org/XML/1998/namespace";
+    NS["XMLNS"] = "http://www.w3.org/2000/xmlns/";
+})(html_NS = html_NS || (html_NS = {}));
+var ATTRS;
+(function (ATTRS) {
+    ATTRS["TYPE"] = "type";
+    ATTRS["ACTION"] = "action";
+    ATTRS["ENCODING"] = "encoding";
+    ATTRS["PROMPT"] = "prompt";
+    ATTRS["NAME"] = "name";
+    ATTRS["COLOR"] = "color";
+    ATTRS["FACE"] = "face";
+    ATTRS["SIZE"] = "size";
+})(ATTRS = ATTRS || (ATTRS = {}));
+/**
+ * The mode of the document.
+ *
+ * @see {@link https://dom.spec.whatwg.org/#concept-document-limited-quirks}
+ */
+var DOCUMENT_MODE;
+(function (DOCUMENT_MODE) {
+    DOCUMENT_MODE["NO_QUIRKS"] = "no-quirks";
+    DOCUMENT_MODE["QUIRKS"] = "quirks";
+    DOCUMENT_MODE["LIMITED_QUIRKS"] = "limited-quirks";
+})(DOCUMENT_MODE = DOCUMENT_MODE || (DOCUMENT_MODE = {}));
+var TAG_NAMES;
+(function (TAG_NAMES) {
+    TAG_NAMES["A"] = "a";
+    TAG_NAMES["ADDRESS"] = "address";
+    TAG_NAMES["ANNOTATION_XML"] = "annotation-xml";
+    TAG_NAMES["APPLET"] = "applet";
+    TAG_NAMES["AREA"] = "area";
+    TAG_NAMES["ARTICLE"] = "article";
+    TAG_NAMES["ASIDE"] = "aside";
+    TAG_NAMES["B"] = "b";
+    TAG_NAMES["BASE"] = "base";
+    TAG_NAMES["BASEFONT"] = "basefont";
+    TAG_NAMES["BGSOUND"] = "bgsound";
+    TAG_NAMES["BIG"] = "big";
+    TAG_NAMES["BLOCKQUOTE"] = "blockquote";
+    TAG_NAMES["BODY"] = "body";
+    TAG_NAMES["BR"] = "br";
+    TAG_NAMES["BUTTON"] = "button";
+    TAG_NAMES["CAPTION"] = "caption";
+    TAG_NAMES["CENTER"] = "center";
+    TAG_NAMES["CODE"] = "code";
+    TAG_NAMES["COL"] = "col";
+    TAG_NAMES["COLGROUP"] = "colgroup";
+    TAG_NAMES["DD"] = "dd";
+    TAG_NAMES["DESC"] = "desc";
+    TAG_NAMES["DETAILS"] = "details";
+    TAG_NAMES["DIALOG"] = "dialog";
+    TAG_NAMES["DIR"] = "dir";
+    TAG_NAMES["DIV"] = "div";
+    TAG_NAMES["DL"] = "dl";
+    TAG_NAMES["DT"] = "dt";
+    TAG_NAMES["EM"] = "em";
+    TAG_NAMES["EMBED"] = "embed";
+    TAG_NAMES["FIELDSET"] = "fieldset";
+    TAG_NAMES["FIGCAPTION"] = "figcaption";
+    TAG_NAMES["FIGURE"] = "figure";
+    TAG_NAMES["FONT"] = "font";
+    TAG_NAMES["FOOTER"] = "footer";
+    TAG_NAMES["FOREIGN_OBJECT"] = "foreignObject";
+    TAG_NAMES["FORM"] = "form";
+    TAG_NAMES["FRAME"] = "frame";
+    TAG_NAMES["FRAMESET"] = "frameset";
+    TAG_NAMES["H1"] = "h1";
+    TAG_NAMES["H2"] = "h2";
+    TAG_NAMES["H3"] = "h3";
+    TAG_NAMES["H4"] = "h4";
+    TAG_NAMES["H5"] = "h5";
+    TAG_NAMES["H6"] = "h6";
+    TAG_NAMES["HEAD"] = "head";
+    TAG_NAMES["HEADER"] = "header";
+    TAG_NAMES["HGROUP"] = "hgroup";
+    TAG_NAMES["HR"] = "hr";
+    TAG_NAMES["HTML"] = "html";
+    TAG_NAMES["I"] = "i";
+    TAG_NAMES["IMG"] = "img";
+    TAG_NAMES["IMAGE"] = "image";
+    TAG_NAMES["INPUT"] = "input";
+    TAG_NAMES["IFRAME"] = "iframe";
+    TAG_NAMES["KEYGEN"] = "keygen";
+    TAG_NAMES["LABEL"] = "label";
+    TAG_NAMES["LI"] = "li";
+    TAG_NAMES["LINK"] = "link";
+    TAG_NAMES["LISTING"] = "listing";
+    TAG_NAMES["MAIN"] = "main";
+    TAG_NAMES["MALIGNMARK"] = "malignmark";
+    TAG_NAMES["MARQUEE"] = "marquee";
+    TAG_NAMES["MATH"] = "math";
+    TAG_NAMES["MENU"] = "menu";
+    TAG_NAMES["META"] = "meta";
+    TAG_NAMES["MGLYPH"] = "mglyph";
+    TAG_NAMES["MI"] = "mi";
+    TAG_NAMES["MO"] = "mo";
+    TAG_NAMES["MN"] = "mn";
+    TAG_NAMES["MS"] = "ms";
+    TAG_NAMES["MTEXT"] = "mtext";
+    TAG_NAMES["NAV"] = "nav";
+    TAG_NAMES["NOBR"] = "nobr";
+    TAG_NAMES["NOFRAMES"] = "noframes";
+    TAG_NAMES["NOEMBED"] = "noembed";
+    TAG_NAMES["NOSCRIPT"] = "noscript";
+    TAG_NAMES["OBJECT"] = "object";
+    TAG_NAMES["OL"] = "ol";
+    TAG_NAMES["OPTGROUP"] = "optgroup";
+    TAG_NAMES["OPTION"] = "option";
+    TAG_NAMES["P"] = "p";
+    TAG_NAMES["PARAM"] = "param";
+    TAG_NAMES["PLAINTEXT"] = "plaintext";
+    TAG_NAMES["PRE"] = "pre";
+    TAG_NAMES["RB"] = "rb";
+    TAG_NAMES["RP"] = "rp";
+    TAG_NAMES["RT"] = "rt";
+    TAG_NAMES["RTC"] = "rtc";
+    TAG_NAMES["RUBY"] = "ruby";
+    TAG_NAMES["S"] = "s";
+    TAG_NAMES["SCRIPT"] = "script";
+    TAG_NAMES["SECTION"] = "section";
+    TAG_NAMES["SELECT"] = "select";
+    TAG_NAMES["SOURCE"] = "source";
+    TAG_NAMES["SMALL"] = "small";
+    TAG_NAMES["SPAN"] = "span";
+    TAG_NAMES["STRIKE"] = "strike";
+    TAG_NAMES["STRONG"] = "strong";
+    TAG_NAMES["STYLE"] = "style";
+    TAG_NAMES["SUB"] = "sub";
+    TAG_NAMES["SUMMARY"] = "summary";
+    TAG_NAMES["SUP"] = "sup";
+    TAG_NAMES["TABLE"] = "table";
+    TAG_NAMES["TBODY"] = "tbody";
+    TAG_NAMES["TEMPLATE"] = "template";
+    TAG_NAMES["TEXTAREA"] = "textarea";
+    TAG_NAMES["TFOOT"] = "tfoot";
+    TAG_NAMES["TD"] = "td";
+    TAG_NAMES["TH"] = "th";
+    TAG_NAMES["THEAD"] = "thead";
+    TAG_NAMES["TITLE"] = "title";
+    TAG_NAMES["TR"] = "tr";
+    TAG_NAMES["TRACK"] = "track";
+    TAG_NAMES["TT"] = "tt";
+    TAG_NAMES["U"] = "u";
+    TAG_NAMES["UL"] = "ul";
+    TAG_NAMES["SVG"] = "svg";
+    TAG_NAMES["VAR"] = "var";
+    TAG_NAMES["WBR"] = "wbr";
+    TAG_NAMES["XMP"] = "xmp";
+})(TAG_NAMES = TAG_NAMES || (TAG_NAMES = {}));
+/**
+ * Tag IDs are numeric IDs for known tag names.
+ *
+ * We use tag IDs to improve the performance of tag name comparisons.
+ */
+var TAG_ID;
+(function (TAG_ID) {
+    TAG_ID[TAG_ID["UNKNOWN"] = 0] = "UNKNOWN";
+    TAG_ID[TAG_ID["A"] = 1] = "A";
+    TAG_ID[TAG_ID["ADDRESS"] = 2] = "ADDRESS";
+    TAG_ID[TAG_ID["ANNOTATION_XML"] = 3] = "ANNOTATION_XML";
+    TAG_ID[TAG_ID["APPLET"] = 4] = "APPLET";
+    TAG_ID[TAG_ID["AREA"] = 5] = "AREA";
+    TAG_ID[TAG_ID["ARTICLE"] = 6] = "ARTICLE";
+    TAG_ID[TAG_ID["ASIDE"] = 7] = "ASIDE";
+    TAG_ID[TAG_ID["B"] = 8] = "B";
+    TAG_ID[TAG_ID["BASE"] = 9] = "BASE";
+    TAG_ID[TAG_ID["BASEFONT"] = 10] = "BASEFONT";
+    TAG_ID[TAG_ID["BGSOUND"] = 11] = "BGSOUND";
+    TAG_ID[TAG_ID["BIG"] = 12] = "BIG";
+    TAG_ID[TAG_ID["BLOCKQUOTE"] = 13] = "BLOCKQUOTE";
+    TAG_ID[TAG_ID["BODY"] = 14] = "BODY";
+    TAG_ID[TAG_ID["BR"] = 15] = "BR";
+    TAG_ID[TAG_ID["BUTTON"] = 16] = "BUTTON";
+    TAG_ID[TAG_ID["CAPTION"] = 17] = "CAPTION";
+    TAG_ID[TAG_ID["CENTER"] = 18] = "CENTER";
+    TAG_ID[TAG_ID["CODE"] = 19] = "CODE";
+    TAG_ID[TAG_ID["COL"] = 20] = "COL";
+    TAG_ID[TAG_ID["COLGROUP"] = 21] = "COLGROUP";
+    TAG_ID[TAG_ID["DD"] = 22] = "DD";
+    TAG_ID[TAG_ID["DESC"] = 23] = "DESC";
+    TAG_ID[TAG_ID["DETAILS"] = 24] = "DETAILS";
+    TAG_ID[TAG_ID["DIALOG"] = 25] = "DIALOG";
+    TAG_ID[TAG_ID["DIR"] = 26] = "DIR";
+    TAG_ID[TAG_ID["DIV"] = 27] = "DIV";
+    TAG_ID[TAG_ID["DL"] = 28] = "DL";
+    TAG_ID[TAG_ID["DT"] = 29] = "DT";
+    TAG_ID[TAG_ID["EM"] = 30] = "EM";
+    TAG_ID[TAG_ID["EMBED"] = 31] = "EMBED";
+    TAG_ID[TAG_ID["FIELDSET"] = 32] = "FIELDSET";
+    TAG_ID[TAG_ID["FIGCAPTION"] = 33] = "FIGCAPTION";
+    TAG_ID[TAG_ID["FIGURE"] = 34] = "FIGURE";
+    TAG_ID[TAG_ID["FONT"] = 35] = "FONT";
+    TAG_ID[TAG_ID["FOOTER"] = 36] = "FOOTER";
+    TAG_ID[TAG_ID["FOREIGN_OBJECT"] = 37] = "FOREIGN_OBJECT";
+    TAG_ID[TAG_ID["FORM"] = 38] = "FORM";
+    TAG_ID[TAG_ID["FRAME"] = 39] = "FRAME";
+    TAG_ID[TAG_ID["FRAMESET"] = 40] = "FRAMESET";
+    TAG_ID[TAG_ID["H1"] = 41] = "H1";
+    TAG_ID[TAG_ID["H2"] = 42] = "H2";
+    TAG_ID[TAG_ID["H3"] = 43] = "H3";
+    TAG_ID[TAG_ID["H4"] = 44] = "H4";
+    TAG_ID[TAG_ID["H5"] = 45] = "H5";
+    TAG_ID[TAG_ID["H6"] = 46] = "H6";
+    TAG_ID[TAG_ID["HEAD"] = 47] = "HEAD";
+    TAG_ID[TAG_ID["HEADER"] = 48] = "HEADER";
+    TAG_ID[TAG_ID["HGROUP"] = 49] = "HGROUP";
+    TAG_ID[TAG_ID["HR"] = 50] = "HR";
+    TAG_ID[TAG_ID["HTML"] = 51] = "HTML";
+    TAG_ID[TAG_ID["I"] = 52] = "I";
+    TAG_ID[TAG_ID["IMG"] = 53] = "IMG";
+    TAG_ID[TAG_ID["IMAGE"] = 54] = "IMAGE";
+    TAG_ID[TAG_ID["INPUT"] = 55] = "INPUT";
+    TAG_ID[TAG_ID["IFRAME"] = 56] = "IFRAME";
+    TAG_ID[TAG_ID["KEYGEN"] = 57] = "KEYGEN";
+    TAG_ID[TAG_ID["LABEL"] = 58] = "LABEL";
+    TAG_ID[TAG_ID["LI"] = 59] = "LI";
+    TAG_ID[TAG_ID["LINK"] = 60] = "LINK";
+    TAG_ID[TAG_ID["LISTING"] = 61] = "LISTING";
+    TAG_ID[TAG_ID["MAIN"] = 62] = "MAIN";
+    TAG_ID[TAG_ID["MALIGNMARK"] = 63] = "MALIGNMARK";
+    TAG_ID[TAG_ID["MARQUEE"] = 64] = "MARQUEE";
+    TAG_ID[TAG_ID["MATH"] = 65] = "MATH";
+    TAG_ID[TAG_ID["MENU"] = 66] = "MENU";
+    TAG_ID[TAG_ID["META"] = 67] = "META";
+    TAG_ID[TAG_ID["MGLYPH"] = 68] = "MGLYPH";
+    TAG_ID[TAG_ID["MI"] = 69] = "MI";
+    TAG_ID[TAG_ID["MO"] = 70] = "MO";
+    TAG_ID[TAG_ID["MN"] = 71] = "MN";
+    TAG_ID[TAG_ID["MS"] = 72] = "MS";
+    TAG_ID[TAG_ID["MTEXT"] = 73] = "MTEXT";
+    TAG_ID[TAG_ID["NAV"] = 74] = "NAV";
+    TAG_ID[TAG_ID["NOBR"] = 75] = "NOBR";
+    TAG_ID[TAG_ID["NOFRAMES"] = 76] = "NOFRAMES";
+    TAG_ID[TAG_ID["NOEMBED"] = 77] = "NOEMBED";
+    TAG_ID[TAG_ID["NOSCRIPT"] = 78] = "NOSCRIPT";
+    TAG_ID[TAG_ID["OBJECT"] = 79] = "OBJECT";
+    TAG_ID[TAG_ID["OL"] = 80] = "OL";
+    TAG_ID[TAG_ID["OPTGROUP"] = 81] = "OPTGROUP";
+    TAG_ID[TAG_ID["OPTION"] = 82] = "OPTION";
+    TAG_ID[TAG_ID["P"] = 83] = "P";
+    TAG_ID[TAG_ID["PARAM"] = 84] = "PARAM";
+    TAG_ID[TAG_ID["PLAINTEXT"] = 85] = "PLAINTEXT";
+    TAG_ID[TAG_ID["PRE"] = 86] = "PRE";
+    TAG_ID[TAG_ID["RB"] = 87] = "RB";
+    TAG_ID[TAG_ID["RP"] = 88] = "RP";
+    TAG_ID[TAG_ID["RT"] = 89] = "RT";
+    TAG_ID[TAG_ID["RTC"] = 90] = "RTC";
+    TAG_ID[TAG_ID["RUBY"] = 91] = "RUBY";
+    TAG_ID[TAG_ID["S"] = 92] = "S";
+    TAG_ID[TAG_ID["SCRIPT"] = 93] = "SCRIPT";
+    TAG_ID[TAG_ID["SECTION"] = 94] = "SECTION";
+    TAG_ID[TAG_ID["SELECT"] = 95] = "SELECT";
+    TAG_ID[TAG_ID["SOURCE"] = 96] = "SOURCE";
+    TAG_ID[TAG_ID["SMALL"] = 97] = "SMALL";
+    TAG_ID[TAG_ID["SPAN"] = 98] = "SPAN";
+    TAG_ID[TAG_ID["STRIKE"] = 99] = "STRIKE";
+    TAG_ID[TAG_ID["STRONG"] = 100] = "STRONG";
+    TAG_ID[TAG_ID["STYLE"] = 101] = "STYLE";
+    TAG_ID[TAG_ID["SUB"] = 102] = "SUB";
+    TAG_ID[TAG_ID["SUMMARY"] = 103] = "SUMMARY";
+    TAG_ID[TAG_ID["SUP"] = 104] = "SUP";
+    TAG_ID[TAG_ID["TABLE"] = 105] = "TABLE";
+    TAG_ID[TAG_ID["TBODY"] = 106] = "TBODY";
+    TAG_ID[TAG_ID["TEMPLATE"] = 107] = "TEMPLATE";
+    TAG_ID[TAG_ID["TEXTAREA"] = 108] = "TEXTAREA";
+    TAG_ID[TAG_ID["TFOOT"] = 109] = "TFOOT";
+    TAG_ID[TAG_ID["TD"] = 110] = "TD";
+    TAG_ID[TAG_ID["TH"] = 111] = "TH";
+    TAG_ID[TAG_ID["THEAD"] = 112] = "THEAD";
+    TAG_ID[TAG_ID["TITLE"] = 113] = "TITLE";
+    TAG_ID[TAG_ID["TR"] = 114] = "TR";
+    TAG_ID[TAG_ID["TRACK"] = 115] = "TRACK";
+    TAG_ID[TAG_ID["TT"] = 116] = "TT";
+    TAG_ID[TAG_ID["U"] = 117] = "U";
+    TAG_ID[TAG_ID["UL"] = 118] = "UL";
+    TAG_ID[TAG_ID["SVG"] = 119] = "SVG";
+    TAG_ID[TAG_ID["VAR"] = 120] = "VAR";
+    TAG_ID[TAG_ID["WBR"] = 121] = "WBR";
+    TAG_ID[TAG_ID["XMP"] = 122] = "XMP";
+})(TAG_ID = TAG_ID || (TAG_ID = {}));
+const TAG_NAME_TO_ID = new Map([
+    [TAG_NAMES.A, TAG_ID.A],
+    [TAG_NAMES.ADDRESS, TAG_ID.ADDRESS],
+    [TAG_NAMES.ANNOTATION_XML, TAG_ID.ANNOTATION_XML],
+    [TAG_NAMES.APPLET, TAG_ID.APPLET],
+    [TAG_NAMES.AREA, TAG_ID.AREA],
+    [TAG_NAMES.ARTICLE, TAG_ID.ARTICLE],
+    [TAG_NAMES.ASIDE, TAG_ID.ASIDE],
+    [TAG_NAMES.B, TAG_ID.B],
+    [TAG_NAMES.BASE, TAG_ID.BASE],
+    [TAG_NAMES.BASEFONT, TAG_ID.BASEFONT],
+    [TAG_NAMES.BGSOUND, TAG_ID.BGSOUND],
+    [TAG_NAMES.BIG, TAG_ID.BIG],
+    [TAG_NAMES.BLOCKQUOTE, TAG_ID.BLOCKQUOTE],
+    [TAG_NAMES.BODY, TAG_ID.BODY],
+    [TAG_NAMES.BR, TAG_ID.BR],
+    [TAG_NAMES.BUTTON, TAG_ID.BUTTON],
+    [TAG_NAMES.CAPTION, TAG_ID.CAPTION],
+    [TAG_NAMES.CENTER, TAG_ID.CENTER],
+    [TAG_NAMES.CODE, TAG_ID.CODE],
+    [TAG_NAMES.COL, TAG_ID.COL],
+    [TAG_NAMES.COLGROUP, TAG_ID.COLGROUP],
+    [TAG_NAMES.DD, TAG_ID.DD],
+    [TAG_NAMES.DESC, TAG_ID.DESC],
+    [TAG_NAMES.DETAILS, TAG_ID.DETAILS],
+    [TAG_NAMES.DIALOG, TAG_ID.DIALOG],
+    [TAG_NAMES.DIR, TAG_ID.DIR],
+    [TAG_NAMES.DIV, TAG_ID.DIV],
+    [TAG_NAMES.DL, TAG_ID.DL],
+    [TAG_NAMES.DT, TAG_ID.DT],
+    [TAG_NAMES.EM, TAG_ID.EM],
+    [TAG_NAMES.EMBED, TAG_ID.EMBED],
+    [TAG_NAMES.FIELDSET, TAG_ID.FIELDSET],
+    [TAG_NAMES.FIGCAPTION, TAG_ID.FIGCAPTION],
+    [TAG_NAMES.FIGURE, TAG_ID.FIGURE],
+    [TAG_NAMES.FONT, TAG_ID.FONT],
+    [TAG_NAMES.FOOTER, TAG_ID.FOOTER],
+    [TAG_NAMES.FOREIGN_OBJECT, TAG_ID.FOREIGN_OBJECT],
+    [TAG_NAMES.FORM, TAG_ID.FORM],
+    [TAG_NAMES.FRAME, TAG_ID.FRAME],
+    [TAG_NAMES.FRAMESET, TAG_ID.FRAMESET],
+    [TAG_NAMES.H1, TAG_ID.H1],
+    [TAG_NAMES.H2, TAG_ID.H2],
+    [TAG_NAMES.H3, TAG_ID.H3],
+    [TAG_NAMES.H4, TAG_ID.H4],
+    [TAG_NAMES.H5, TAG_ID.H5],
+    [TAG_NAMES.H6, TAG_ID.H6],
+    [TAG_NAMES.HEAD, TAG_ID.HEAD],
+    [TAG_NAMES.HEADER, TAG_ID.HEADER],
+    [TAG_NAMES.HGROUP, TAG_ID.HGROUP],
+    [TAG_NAMES.HR, TAG_ID.HR],
+    [TAG_NAMES.HTML, TAG_ID.HTML],
+    [TAG_NAMES.I, TAG_ID.I],
+    [TAG_NAMES.IMG, TAG_ID.IMG],
+    [TAG_NAMES.IMAGE, TAG_ID.IMAGE],
+    [TAG_NAMES.INPUT, TAG_ID.INPUT],
+    [TAG_NAMES.IFRAME, TAG_ID.IFRAME],
+    [TAG_NAMES.KEYGEN, TAG_ID.KEYGEN],
+    [TAG_NAMES.LABEL, TAG_ID.LABEL],
+    [TAG_NAMES.LI, TAG_ID.LI],
+    [TAG_NAMES.LINK, TAG_ID.LINK],
+    [TAG_NAMES.LISTING, TAG_ID.LISTING],
+    [TAG_NAMES.MAIN, TAG_ID.MAIN],
+    [TAG_NAMES.MALIGNMARK, TAG_ID.MALIGNMARK],
+    [TAG_NAMES.MARQUEE, TAG_ID.MARQUEE],
+    [TAG_NAMES.MATH, TAG_ID.MATH],
+    [TAG_NAMES.MENU, TAG_ID.MENU],
+    [TAG_NAMES.META, TAG_ID.META],
+    [TAG_NAMES.MGLYPH, TAG_ID.MGLYPH],
+    [TAG_NAMES.MI, TAG_ID.MI],
+    [TAG_NAMES.MO, TAG_ID.MO],
+    [TAG_NAMES.MN, TAG_ID.MN],
+    [TAG_NAMES.MS, TAG_ID.MS],
+    [TAG_NAMES.MTEXT, TAG_ID.MTEXT],
+    [TAG_NAMES.NAV, TAG_ID.NAV],
+    [TAG_NAMES.NOBR, TAG_ID.NOBR],
+    [TAG_NAMES.NOFRAMES, TAG_ID.NOFRAMES],
+    [TAG_NAMES.NOEMBED, TAG_ID.NOEMBED],
+    [TAG_NAMES.NOSCRIPT, TAG_ID.NOSCRIPT],
+    [TAG_NAMES.OBJECT, TAG_ID.OBJECT],
+    [TAG_NAMES.OL, TAG_ID.OL],
+    [TAG_NAMES.OPTGROUP, TAG_ID.OPTGROUP],
+    [TAG_NAMES.OPTION, TAG_ID.OPTION],
+    [TAG_NAMES.P, TAG_ID.P],
+    [TAG_NAMES.PARAM, TAG_ID.PARAM],
+    [TAG_NAMES.PLAINTEXT, TAG_ID.PLAINTEXT],
+    [TAG_NAMES.PRE, TAG_ID.PRE],
+    [TAG_NAMES.RB, TAG_ID.RB],
+    [TAG_NAMES.RP, TAG_ID.RP],
+    [TAG_NAMES.RT, TAG_ID.RT],
+    [TAG_NAMES.RTC, TAG_ID.RTC],
+    [TAG_NAMES.RUBY, TAG_ID.RUBY],
+    [TAG_NAMES.S, TAG_ID.S],
+    [TAG_NAMES.SCRIPT, TAG_ID.SCRIPT],
+    [TAG_NAMES.SECTION, TAG_ID.SECTION],
+    [TAG_NAMES.SELECT, TAG_ID.SELECT],
+    [TAG_NAMES.SOURCE, TAG_ID.SOURCE],
+    [TAG_NAMES.SMALL, TAG_ID.SMALL],
+    [TAG_NAMES.SPAN, TAG_ID.SPAN],
+    [TAG_NAMES.STRIKE, TAG_ID.STRIKE],
+    [TAG_NAMES.STRONG, TAG_ID.STRONG],
+    [TAG_NAMES.STYLE, TAG_ID.STYLE],
+    [TAG_NAMES.SUB, TAG_ID.SUB],
+    [TAG_NAMES.SUMMARY, TAG_ID.SUMMARY],
+    [TAG_NAMES.SUP, TAG_ID.SUP],
+    [TAG_NAMES.TABLE, TAG_ID.TABLE],
+    [TAG_NAMES.TBODY, TAG_ID.TBODY],
+    [TAG_NAMES.TEMPLATE, TAG_ID.TEMPLATE],
+    [TAG_NAMES.TEXTAREA, TAG_ID.TEXTAREA],
+    [TAG_NAMES.TFOOT, TAG_ID.TFOOT],
+    [TAG_NAMES.TD, TAG_ID.TD],
+    [TAG_NAMES.TH, TAG_ID.TH],
+    [TAG_NAMES.THEAD, TAG_ID.THEAD],
+    [TAG_NAMES.TITLE, TAG_ID.TITLE],
+    [TAG_NAMES.TR, TAG_ID.TR],
+    [TAG_NAMES.TRACK, TAG_ID.TRACK],
+    [TAG_NAMES.TT, TAG_ID.TT],
+    [TAG_NAMES.U, TAG_ID.U],
+    [TAG_NAMES.UL, TAG_ID.UL],
+    [TAG_NAMES.SVG, TAG_ID.SVG],
+    [TAG_NAMES.VAR, TAG_ID.VAR],
+    [TAG_NAMES.WBR, TAG_ID.WBR],
+    [TAG_NAMES.XMP, TAG_ID.XMP],
+]);
+function getTagID(tagName) {
+    var _a;
+    return (_a = TAG_NAME_TO_ID.get(tagName)) !== null && _a !== void 0 ? _a : TAG_ID.UNKNOWN;
+}
+const html_$ = TAG_ID;
+const SPECIAL_ELEMENTS = {
+    [html_NS.HTML]: new Set([
+        html_$.ADDRESS,
+        html_$.APPLET,
+        html_$.AREA,
+        html_$.ARTICLE,
+        html_$.ASIDE,
+        html_$.BASE,
+        html_$.BASEFONT,
+        html_$.BGSOUND,
+        html_$.BLOCKQUOTE,
+        html_$.BODY,
+        html_$.BR,
+        html_$.BUTTON,
+        html_$.CAPTION,
+        html_$.CENTER,
+        html_$.COL,
+        html_$.COLGROUP,
+        html_$.DD,
+        html_$.DETAILS,
+        html_$.DIR,
+        html_$.DIV,
+        html_$.DL,
+        html_$.DT,
+        html_$.EMBED,
+        html_$.FIELDSET,
+        html_$.FIGCAPTION,
+        html_$.FIGURE,
+        html_$.FOOTER,
+        html_$.FORM,
+        html_$.FRAME,
+        html_$.FRAMESET,
+        html_$.H1,
+        html_$.H2,
+        html_$.H3,
+        html_$.H4,
+        html_$.H5,
+        html_$.H6,
+        html_$.HEAD,
+        html_$.HEADER,
+        html_$.HGROUP,
+        html_$.HR,
+        html_$.HTML,
+        html_$.IFRAME,
+        html_$.IMG,
+        html_$.INPUT,
+        html_$.LI,
+        html_$.LINK,
+        html_$.LISTING,
+        html_$.MAIN,
+        html_$.MARQUEE,
+        html_$.MENU,
+        html_$.META,
+        html_$.NAV,
+        html_$.NOEMBED,
+        html_$.NOFRAMES,
+        html_$.NOSCRIPT,
+        html_$.OBJECT,
+        html_$.OL,
+        html_$.P,
+        html_$.PARAM,
+        html_$.PLAINTEXT,
+        html_$.PRE,
+        html_$.SCRIPT,
+        html_$.SECTION,
+        html_$.SELECT,
+        html_$.SOURCE,
+        html_$.STYLE,
+        html_$.SUMMARY,
+        html_$.TABLE,
+        html_$.TBODY,
+        html_$.TD,
+        html_$.TEMPLATE,
+        html_$.TEXTAREA,
+        html_$.TFOOT,
+        html_$.TH,
+        html_$.THEAD,
+        html_$.TITLE,
+        html_$.TR,
+        html_$.TRACK,
+        html_$.UL,
+        html_$.WBR,
+        html_$.XMP,
+    ]),
+    [html_NS.MATHML]: new Set([html_$.MI, html_$.MO, html_$.MN, html_$.MS, html_$.MTEXT, html_$.ANNOTATION_XML]),
+    [html_NS.SVG]: new Set([html_$.TITLE, html_$.FOREIGN_OBJECT, html_$.DESC]),
+    [html_NS.XLINK]: new Set(),
+    [html_NS.XML]: new Set(),
+    [html_NS.XMLNS]: new Set(),
+};
+function isNumberedHeader(tn) {
+    return tn === html_$.H1 || tn === html_$.H2 || tn === html_$.H3 || tn === html_$.H4 || tn === html_$.H5 || tn === html_$.H6;
+}
+const UNESCAPED_TEXT = new Set([
+    TAG_NAMES.STYLE,
+    TAG_NAMES.SCRIPT,
+    TAG_NAMES.XMP,
+    TAG_NAMES.IFRAME,
+    TAG_NAMES.NOEMBED,
+    TAG_NAMES.NOFRAMES,
+    TAG_NAMES.PLAINTEXT,
+]);
+function html_hasUnescapedText(tn, scriptingEnabled) {
+    return UNESCAPED_TEXT.has(tn) || (scriptingEnabled && tn === TAG_NAMES.NOSCRIPT);
+}
+//# sourceMappingURL=html.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/tokenizer/index.js
+
+
+
+
+
+
+//C1 Unicode control character reference replacements
+const C1_CONTROLS_REFERENCE_REPLACEMENTS = new Map([
+    [0x80, 8364],
+    [0x82, 8218],
+    [0x83, 402],
+    [0x84, 8222],
+    [0x85, 8230],
+    [0x86, 8224],
+    [0x87, 8225],
+    [0x88, 710],
+    [0x89, 8240],
+    [0x8a, 352],
+    [0x8b, 8249],
+    [0x8c, 338],
+    [0x8e, 381],
+    [0x91, 8216],
+    [0x92, 8217],
+    [0x93, 8220],
+    [0x94, 8221],
+    [0x95, 8226],
+    [0x96, 8211],
+    [0x97, 8212],
+    [0x98, 732],
+    [0x99, 8482],
+    [0x9a, 353],
+    [0x9b, 8250],
+    [0x9c, 339],
+    [0x9e, 382],
+    [0x9f, 376],
+]);
+//States
+var State;
+(function (State) {
+    State[State["DATA"] = 0] = "DATA";
+    State[State["RCDATA"] = 1] = "RCDATA";
+    State[State["RAWTEXT"] = 2] = "RAWTEXT";
+    State[State["SCRIPT_DATA"] = 3] = "SCRIPT_DATA";
+    State[State["PLAINTEXT"] = 4] = "PLAINTEXT";
+    State[State["TAG_OPEN"] = 5] = "TAG_OPEN";
+    State[State["END_TAG_OPEN"] = 6] = "END_TAG_OPEN";
+    State[State["TAG_NAME"] = 7] = "TAG_NAME";
+    State[State["RCDATA_LESS_THAN_SIGN"] = 8] = "RCDATA_LESS_THAN_SIGN";
+    State[State["RCDATA_END_TAG_OPEN"] = 9] = "RCDATA_END_TAG_OPEN";
+    State[State["RCDATA_END_TAG_NAME"] = 10] = "RCDATA_END_TAG_NAME";
+    State[State["RAWTEXT_LESS_THAN_SIGN"] = 11] = "RAWTEXT_LESS_THAN_SIGN";
+    State[State["RAWTEXT_END_TAG_OPEN"] = 12] = "RAWTEXT_END_TAG_OPEN";
+    State[State["RAWTEXT_END_TAG_NAME"] = 13] = "RAWTEXT_END_TAG_NAME";
+    State[State["SCRIPT_DATA_LESS_THAN_SIGN"] = 14] = "SCRIPT_DATA_LESS_THAN_SIGN";
+    State[State["SCRIPT_DATA_END_TAG_OPEN"] = 15] = "SCRIPT_DATA_END_TAG_OPEN";
+    State[State["SCRIPT_DATA_END_TAG_NAME"] = 16] = "SCRIPT_DATA_END_TAG_NAME";
+    State[State["SCRIPT_DATA_ESCAPE_START"] = 17] = "SCRIPT_DATA_ESCAPE_START";
+    State[State["SCRIPT_DATA_ESCAPE_START_DASH"] = 18] = "SCRIPT_DATA_ESCAPE_START_DASH";
+    State[State["SCRIPT_DATA_ESCAPED"] = 19] = "SCRIPT_DATA_ESCAPED";
+    State[State["SCRIPT_DATA_ESCAPED_DASH"] = 20] = "SCRIPT_DATA_ESCAPED_DASH";
+    State[State["SCRIPT_DATA_ESCAPED_DASH_DASH"] = 21] = "SCRIPT_DATA_ESCAPED_DASH_DASH";
+    State[State["SCRIPT_DATA_ESCAPED_LESS_THAN_SIGN"] = 22] = "SCRIPT_DATA_ESCAPED_LESS_THAN_SIGN";
+    State[State["SCRIPT_DATA_ESCAPED_END_TAG_OPEN"] = 23] = "SCRIPT_DATA_ESCAPED_END_TAG_OPEN";
+    State[State["SCRIPT_DATA_ESCAPED_END_TAG_NAME"] = 24] = "SCRIPT_DATA_ESCAPED_END_TAG_NAME";
+    State[State["SCRIPT_DATA_DOUBLE_ESCAPE_START"] = 25] = "SCRIPT_DATA_DOUBLE_ESCAPE_START";
+    State[State["SCRIPT_DATA_DOUBLE_ESCAPED"] = 26] = "SCRIPT_DATA_DOUBLE_ESCAPED";
+    State[State["SCRIPT_DATA_DOUBLE_ESCAPED_DASH"] = 27] = "SCRIPT_DATA_DOUBLE_ESCAPED_DASH";
+    State[State["SCRIPT_DATA_DOUBLE_ESCAPED_DASH_DASH"] = 28] = "SCRIPT_DATA_DOUBLE_ESCAPED_DASH_DASH";
+    State[State["SCRIPT_DATA_DOUBLE_ESCAPED_LESS_THAN_SIGN"] = 29] = "SCRIPT_DATA_DOUBLE_ESCAPED_LESS_THAN_SIGN";
+    State[State["SCRIPT_DATA_DOUBLE_ESCAPE_END"] = 30] = "SCRIPT_DATA_DOUBLE_ESCAPE_END";
+    State[State["BEFORE_ATTRIBUTE_NAME"] = 31] = "BEFORE_ATTRIBUTE_NAME";
+    State[State["ATTRIBUTE_NAME"] = 32] = "ATTRIBUTE_NAME";
+    State[State["AFTER_ATTRIBUTE_NAME"] = 33] = "AFTER_ATTRIBUTE_NAME";
+    State[State["BEFORE_ATTRIBUTE_VALUE"] = 34] = "BEFORE_ATTRIBUTE_VALUE";
+    State[State["ATTRIBUTE_VALUE_DOUBLE_QUOTED"] = 35] = "ATTRIBUTE_VALUE_DOUBLE_QUOTED";
+    State[State["ATTRIBUTE_VALUE_SINGLE_QUOTED"] = 36] = "ATTRIBUTE_VALUE_SINGLE_QUOTED";
+    State[State["ATTRIBUTE_VALUE_UNQUOTED"] = 37] = "ATTRIBUTE_VALUE_UNQUOTED";
+    State[State["AFTER_ATTRIBUTE_VALUE_QUOTED"] = 38] = "AFTER_ATTRIBUTE_VALUE_QUOTED";
+    State[State["SELF_CLOSING_START_TAG"] = 39] = "SELF_CLOSING_START_TAG";
+    State[State["BOGUS_COMMENT"] = 40] = "BOGUS_COMMENT";
+    State[State["MARKUP_DECLARATION_OPEN"] = 41] = "MARKUP_DECLARATION_OPEN";
+    State[State["COMMENT_START"] = 42] = "COMMENT_START";
+    State[State["COMMENT_START_DASH"] = 43] = "COMMENT_START_DASH";
+    State[State["COMMENT"] = 44] = "COMMENT";
+    State[State["COMMENT_LESS_THAN_SIGN"] = 45] = "COMMENT_LESS_THAN_SIGN";
+    State[State["COMMENT_LESS_THAN_SIGN_BANG"] = 46] = "COMMENT_LESS_THAN_SIGN_BANG";
+    State[State["COMMENT_LESS_THAN_SIGN_BANG_DASH"] = 47] = "COMMENT_LESS_THAN_SIGN_BANG_DASH";
+    State[State["COMMENT_LESS_THAN_SIGN_BANG_DASH_DASH"] = 48] = "COMMENT_LESS_THAN_SIGN_BANG_DASH_DASH";
+    State[State["COMMENT_END_DASH"] = 49] = "COMMENT_END_DASH";
+    State[State["COMMENT_END"] = 50] = "COMMENT_END";
+    State[State["COMMENT_END_BANG"] = 51] = "COMMENT_END_BANG";
+    State[State["DOCTYPE"] = 52] = "DOCTYPE";
+    State[State["BEFORE_DOCTYPE_NAME"] = 53] = "BEFORE_DOCTYPE_NAME";
+    State[State["DOCTYPE_NAME"] = 54] = "DOCTYPE_NAME";
+    State[State["AFTER_DOCTYPE_NAME"] = 55] = "AFTER_DOCTYPE_NAME";
+    State[State["AFTER_DOCTYPE_PUBLIC_KEYWORD"] = 56] = "AFTER_DOCTYPE_PUBLIC_KEYWORD";
+    State[State["BEFORE_DOCTYPE_PUBLIC_IDENTIFIER"] = 57] = "BEFORE_DOCTYPE_PUBLIC_IDENTIFIER";
+    State[State["DOCTYPE_PUBLIC_IDENTIFIER_DOUBLE_QUOTED"] = 58] = "DOCTYPE_PUBLIC_IDENTIFIER_DOUBLE_QUOTED";
+    State[State["DOCTYPE_PUBLIC_IDENTIFIER_SINGLE_QUOTED"] = 59] = "DOCTYPE_PUBLIC_IDENTIFIER_SINGLE_QUOTED";
+    State[State["AFTER_DOCTYPE_PUBLIC_IDENTIFIER"] = 60] = "AFTER_DOCTYPE_PUBLIC_IDENTIFIER";
+    State[State["BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS"] = 61] = "BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS";
+    State[State["AFTER_DOCTYPE_SYSTEM_KEYWORD"] = 62] = "AFTER_DOCTYPE_SYSTEM_KEYWORD";
+    State[State["BEFORE_DOCTYPE_SYSTEM_IDENTIFIER"] = 63] = "BEFORE_DOCTYPE_SYSTEM_IDENTIFIER";
+    State[State["DOCTYPE_SYSTEM_IDENTIFIER_DOUBLE_QUOTED"] = 64] = "DOCTYPE_SYSTEM_IDENTIFIER_DOUBLE_QUOTED";
+    State[State["DOCTYPE_SYSTEM_IDENTIFIER_SINGLE_QUOTED"] = 65] = "DOCTYPE_SYSTEM_IDENTIFIER_SINGLE_QUOTED";
+    State[State["AFTER_DOCTYPE_SYSTEM_IDENTIFIER"] = 66] = "AFTER_DOCTYPE_SYSTEM_IDENTIFIER";
+    State[State["BOGUS_DOCTYPE"] = 67] = "BOGUS_DOCTYPE";
+    State[State["CDATA_SECTION"] = 68] = "CDATA_SECTION";
+    State[State["CDATA_SECTION_BRACKET"] = 69] = "CDATA_SECTION_BRACKET";
+    State[State["CDATA_SECTION_END"] = 70] = "CDATA_SECTION_END";
+    State[State["CHARACTER_REFERENCE"] = 71] = "CHARACTER_REFERENCE";
+    State[State["NAMED_CHARACTER_REFERENCE"] = 72] = "NAMED_CHARACTER_REFERENCE";
+    State[State["AMBIGUOUS_AMPERSAND"] = 73] = "AMBIGUOUS_AMPERSAND";
+    State[State["NUMERIC_CHARACTER_REFERENCE"] = 74] = "NUMERIC_CHARACTER_REFERENCE";
+    State[State["HEXADEMICAL_CHARACTER_REFERENCE_START"] = 75] = "HEXADEMICAL_CHARACTER_REFERENCE_START";
+    State[State["HEXADEMICAL_CHARACTER_REFERENCE"] = 76] = "HEXADEMICAL_CHARACTER_REFERENCE";
+    State[State["DECIMAL_CHARACTER_REFERENCE"] = 77] = "DECIMAL_CHARACTER_REFERENCE";
+    State[State["NUMERIC_CHARACTER_REFERENCE_END"] = 78] = "NUMERIC_CHARACTER_REFERENCE_END";
+})(State || (State = {}));
+//Tokenizer initial states for different modes
+const TokenizerMode = {
+    DATA: State.DATA,
+    RCDATA: State.RCDATA,
+    RAWTEXT: State.RAWTEXT,
+    SCRIPT_DATA: State.SCRIPT_DATA,
+    PLAINTEXT: State.PLAINTEXT,
+    CDATA_SECTION: State.CDATA_SECTION,
+};
+//Utils
+//OPTIMIZATION: these utility functions should not be moved out of this module. V8 Crankshaft will not inline
+//this functions if they will be situated in another module due to context switch.
+//Always perform inlining check before modifying this functions ('node --trace-inlining').
+function isAsciiDigit(cp) {
+    return cp >= CODE_POINTS.DIGIT_0 && cp <= CODE_POINTS.DIGIT_9;
+}
+function isAsciiUpper(cp) {
+    return cp >= CODE_POINTS.LATIN_CAPITAL_A && cp <= CODE_POINTS.LATIN_CAPITAL_Z;
+}
+function isAsciiLower(cp) {
+    return cp >= CODE_POINTS.LATIN_SMALL_A && cp <= CODE_POINTS.LATIN_SMALL_Z;
+}
+function isAsciiLetter(cp) {
+    return isAsciiLower(cp) || isAsciiUpper(cp);
+}
+function tokenizer_isAsciiAlphaNumeric(cp) {
+    return isAsciiLetter(cp) || isAsciiDigit(cp);
+}
+function isAsciiUpperHexDigit(cp) {
+    return cp >= CODE_POINTS.LATIN_CAPITAL_A && cp <= CODE_POINTS.LATIN_CAPITAL_F;
+}
+function isAsciiLowerHexDigit(cp) {
+    return cp >= CODE_POINTS.LATIN_SMALL_A && cp <= CODE_POINTS.LATIN_SMALL_F;
+}
+function isAsciiHexDigit(cp) {
+    return isAsciiDigit(cp) || isAsciiUpperHexDigit(cp) || isAsciiLowerHexDigit(cp);
+}
+function toAsciiLower(cp) {
+    return cp + 32;
+}
+function isWhitespace(cp) {
+    return cp === CODE_POINTS.SPACE || cp === CODE_POINTS.LINE_FEED || cp === CODE_POINTS.TABULATION || cp === CODE_POINTS.FORM_FEED;
+}
+function tokenizer_isEntityInAttributeInvalidEnd(nextCp) {
+    return nextCp === CODE_POINTS.EQUALS_SIGN || tokenizer_isAsciiAlphaNumeric(nextCp);
+}
+function isScriptDataDoubleEscapeSequenceEnd(cp) {
+    return isWhitespace(cp) || cp === CODE_POINTS.SOLIDUS || cp === CODE_POINTS.GREATER_THAN_SIGN;
+}
+//Tokenizer
+class Tokenizer {
+    constructor(options, handler) {
+        this.options = options;
+        this.handler = handler;
+        this.paused = false;
+        /** Ensures that the parsing loop isn't run multiple times at once. */
+        this.inLoop = false;
+        /**
+         * Indicates that the current adjusted node exists, is not an element in the HTML namespace,
+         * and that it is not an integration point for either MathML or HTML.
+         *
+         * @see {@link https://html.spec.whatwg.org/multipage/parsing.html#tree-construction}
+         */
+        this.inForeignNode = false;
+        this.lastStartTagName = '';
+        this.active = false;
+        this.state = State.DATA;
+        this.returnState = State.DATA;
+        this.charRefCode = -1;
+        this.consumedAfterSnapshot = -1;
+        this.currentCharacterToken = null;
+        this.currentToken = null;
+        this.currentAttr = { name: '', value: '' };
+        this.preprocessor = new Preprocessor(handler);
+        this.currentLocation = this.getCurrentLocation(-1);
+    }
+    //Errors
+    _err(code) {
+        var _a, _b;
+        (_b = (_a = this.handler).onParseError) === null || _b === void 0 ? void 0 : _b.call(_a, this.preprocessor.getError(code));
+    }
+    // NOTE: `offset` may never run across line boundaries.
+    getCurrentLocation(offset) {
+        if (!this.options.sourceCodeLocationInfo) {
+            return null;
+        }
+        return {
+            startLine: this.preprocessor.line,
+            startCol: this.preprocessor.col - offset,
+            startOffset: this.preprocessor.offset - offset,
+            endLine: -1,
+            endCol: -1,
+            endOffset: -1,
+        };
+    }
+    _runParsingLoop() {
+        if (this.inLoop)
+            return;
+        this.inLoop = true;
+        while (this.active && !this.paused) {
+            this.consumedAfterSnapshot = 0;
+            const cp = this._consume();
+            if (!this._ensureHibernation()) {
+                this._callState(cp);
+            }
+        }
+        this.inLoop = false;
+    }
+    //API
+    pause() {
+        this.paused = true;
+    }
+    resume(writeCallback) {
+        if (!this.paused) {
+            throw new Error('Parser was already resumed');
+        }
+        this.paused = false;
+        // Necessary for synchronous resume.
+        if (this.inLoop)
+            return;
+        this._runParsingLoop();
+        if (!this.paused) {
+            writeCallback === null || writeCallback === void 0 ? void 0 : writeCallback();
+        }
+    }
+    write(chunk, isLastChunk, writeCallback) {
+        this.active = true;
+        this.preprocessor.write(chunk, isLastChunk);
+        this._runParsingLoop();
+        if (!this.paused) {
+            writeCallback === null || writeCallback === void 0 ? void 0 : writeCallback();
+        }
+    }
+    insertHtmlAtCurrentPos(chunk) {
+        this.active = true;
+        this.preprocessor.insertHtmlAtCurrentPos(chunk);
+        this._runParsingLoop();
+    }
+    //Hibernation
+    _ensureHibernation() {
+        if (this.preprocessor.endOfChunkHit) {
+            this._unconsume(this.consumedAfterSnapshot);
+            this.active = false;
+            return true;
+        }
+        return false;
+    }
+    //Consumption
+    _consume() {
+        this.consumedAfterSnapshot++;
+        return this.preprocessor.advance();
+    }
+    _unconsume(count) {
+        this.consumedAfterSnapshot -= count;
+        this.preprocessor.retreat(count);
+    }
+    _reconsumeInState(state, cp) {
+        this.state = state;
+        this._callState(cp);
+    }
+    _advanceBy(count) {
+        this.consumedAfterSnapshot += count;
+        for (let i = 0; i < count; i++) {
+            this.preprocessor.advance();
+        }
+    }
+    _consumeSequenceIfMatch(pattern, caseSensitive) {
+        if (this.preprocessor.startsWith(pattern, caseSensitive)) {
+            // We will already have consumed one character before calling this method.
+            this._advanceBy(pattern.length - 1);
+            return true;
+        }
+        return false;
+    }
+    //Token creation
+    _createStartTagToken() {
+        this.currentToken = {
+            type: TokenType.START_TAG,
+            tagName: '',
+            tagID: TAG_ID.UNKNOWN,
+            selfClosing: false,
+            ackSelfClosing: false,
+            attrs: [],
+            location: this.getCurrentLocation(1),
+        };
+    }
+    _createEndTagToken() {
+        this.currentToken = {
+            type: TokenType.END_TAG,
+            tagName: '',
+            tagID: TAG_ID.UNKNOWN,
+            selfClosing: false,
+            ackSelfClosing: false,
+            attrs: [],
+            location: this.getCurrentLocation(2),
+        };
+    }
+    _createCommentToken(offset) {
+        this.currentToken = {
+            type: TokenType.COMMENT,
+            data: '',
+            location: this.getCurrentLocation(offset),
+        };
+    }
+    _createDoctypeToken(initialName) {
+        this.currentToken = {
+            type: TokenType.DOCTYPE,
+            name: initialName,
+            forceQuirks: false,
+            publicId: null,
+            systemId: null,
+            location: this.currentLocation,
+        };
+    }
+    _createCharacterToken(type, chars) {
+        this.currentCharacterToken = {
+            type,
+            chars,
+            location: this.currentLocation,
+        };
+    }
+    //Tag attributes
+    _createAttr(attrNameFirstCh) {
+        this.currentAttr = {
+            name: attrNameFirstCh,
+            value: '',
+        };
+        this.currentLocation = this.getCurrentLocation(0);
+    }
+    _leaveAttrName() {
+        var _a;
+        var _b;
+        const token = this.currentToken;
+        if (getTokenAttr(token, this.currentAttr.name) === null) {
+            token.attrs.push(this.currentAttr);
+            if (token.location && this.currentLocation) {
+                const attrLocations = ((_a = (_b = token.location).attrs) !== null && _a !== void 0 ? _a : (_b.attrs = Object.create(null)));
+                attrLocations[this.currentAttr.name] = this.currentLocation;
+                // Set end location
+                this._leaveAttrValue();
+            }
+        }
+        else {
+            this._err(ERR.duplicateAttribute);
+        }
+    }
+    _leaveAttrValue() {
+        if (this.currentLocation) {
+            this.currentLocation.endLine = this.preprocessor.line;
+            this.currentLocation.endCol = this.preprocessor.col;
+            this.currentLocation.endOffset = this.preprocessor.offset;
+        }
+    }
+    //Token emission
+    prepareToken(ct) {
+        this._emitCurrentCharacterToken(ct.location);
+        this.currentToken = null;
+        if (ct.location) {
+            ct.location.endLine = this.preprocessor.line;
+            ct.location.endCol = this.preprocessor.col + 1;
+            ct.location.endOffset = this.preprocessor.offset + 1;
+        }
+        this.currentLocation = this.getCurrentLocation(-1);
+    }
+    emitCurrentTagToken() {
+        const ct = this.currentToken;
+        this.prepareToken(ct);
+        ct.tagID = getTagID(ct.tagName);
+        if (ct.type === TokenType.START_TAG) {
+            this.lastStartTagName = ct.tagName;
+            this.handler.onStartTag(ct);
+        }
+        else {
+            if (ct.attrs.length > 0) {
+                this._err(ERR.endTagWithAttributes);
+            }
+            if (ct.selfClosing) {
+                this._err(ERR.endTagWithTrailingSolidus);
+            }
+            this.handler.onEndTag(ct);
+        }
+        this.preprocessor.dropParsedChunk();
+    }
+    emitCurrentComment(ct) {
+        this.prepareToken(ct);
+        this.handler.onComment(ct);
+        this.preprocessor.dropParsedChunk();
+    }
+    emitCurrentDoctype(ct) {
+        this.prepareToken(ct);
+        this.handler.onDoctype(ct);
+        this.preprocessor.dropParsedChunk();
+    }
+    _emitCurrentCharacterToken(nextLocation) {
+        if (this.currentCharacterToken) {
+            //NOTE: if we have a pending character token, make it's end location equal to the
+            //current token's start location.
+            if (nextLocation && this.currentCharacterToken.location) {
+                this.currentCharacterToken.location.endLine = nextLocation.startLine;
+                this.currentCharacterToken.location.endCol = nextLocation.startCol;
+                this.currentCharacterToken.location.endOffset = nextLocation.startOffset;
+            }
+            switch (this.currentCharacterToken.type) {
+                case TokenType.CHARACTER: {
+                    this.handler.onCharacter(this.currentCharacterToken);
+                    break;
+                }
+                case TokenType.NULL_CHARACTER: {
+                    this.handler.onNullCharacter(this.currentCharacterToken);
+                    break;
+                }
+                case TokenType.WHITESPACE_CHARACTER: {
+                    this.handler.onWhitespaceCharacter(this.currentCharacterToken);
+                    break;
+                }
+            }
+            this.currentCharacterToken = null;
+        }
+    }
+    _emitEOFToken() {
+        const location = this.getCurrentLocation(0);
+        if (location) {
+            location.endLine = location.startLine;
+            location.endCol = location.startCol;
+            location.endOffset = location.startOffset;
+        }
+        this._emitCurrentCharacterToken(location);
+        this.handler.onEof({ type: TokenType.EOF, location });
+        this.active = false;
+    }
+    //Characters emission
+    //OPTIMIZATION: specification uses only one type of character tokens (one token per character).
+    //This causes a huge memory overhead and a lot of unnecessary parser loops. parse5 uses 3 groups of characters.
+    //If we have a sequence of characters that belong to the same group, the parser can process it
+    //as a single solid character token.
+    //So, there are 3 types of character tokens in parse5:
+    //1)TokenType.NULL_CHARACTER - \u0000-character sequences (e.g. '\u0000\u0000\u0000')
+    //2)TokenType.WHITESPACE_CHARACTER - any whitespace/new-line character sequences (e.g. '\n  \r\t   \f')
+    //3)TokenType.CHARACTER - any character sequence which don't belong to groups 1 and 2 (e.g. 'abcdef1234@@#$%^')
+    _appendCharToCurrentCharacterToken(type, ch) {
+        if (this.currentCharacterToken) {
+            if (this.currentCharacterToken.type !== type) {
+                this.currentLocation = this.getCurrentLocation(0);
+                this._emitCurrentCharacterToken(this.currentLocation);
+                this.preprocessor.dropParsedChunk();
+            }
+            else {
+                this.currentCharacterToken.chars += ch;
+                return;
+            }
+        }
+        this._createCharacterToken(type, ch);
+    }
+    _emitCodePoint(cp) {
+        const type = isWhitespace(cp)
+            ? TokenType.WHITESPACE_CHARACTER
+            : cp === CODE_POINTS.NULL
+                ? TokenType.NULL_CHARACTER
+                : TokenType.CHARACTER;
+        this._appendCharToCurrentCharacterToken(type, String.fromCodePoint(cp));
+    }
+    //NOTE: used when we emit characters explicitly.
+    //This is always for non-whitespace and non-null characters, which allows us to avoid additional checks.
+    _emitChars(ch) {
+        this._appendCharToCurrentCharacterToken(TokenType.CHARACTER, ch);
+    }
+    // Character reference helpers
+    _matchNamedCharacterReference(cp) {
+        let result = null;
+        let excess = 0;
+        let withoutSemicolon = false;
+        for (let i = 0, current = decode_data_html[0]; i >= 0; cp = this._consume()) {
+            i = determineBranch(decode_data_html, current, i + 1, cp);
+            if (i < 0)
+                break;
+            excess += 1;
+            current = decode_data_html[i];
+            const masked = current & BinTrieFlags.VALUE_LENGTH;
+            // If the branch is a value, store it and continue
+            if (masked) {
+                // The mask is the number of bytes of the value, including the current byte.
+                const valueLength = (masked >> 14) - 1;
+                // Attribute values that aren't terminated properly aren't parsed, and shouldn't lead to a parser error.
+                // See the example in https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state
+                if (cp !== CODE_POINTS.SEMICOLON &&
+                    this._isCharacterReferenceInAttribute() &&
+                    tokenizer_isEntityInAttributeInvalidEnd(this.preprocessor.peek(1))) {
+                    //NOTE: we don't flush all consumed code points here, and instead switch back to the original state after
+                    //emitting an ampersand. This is fine, as alphanumeric characters won't be parsed differently in attributes.
+                    result = [CODE_POINTS.AMPERSAND];
+                    // Skip over the value.
+                    i += valueLength;
+                }
+                else {
+                    // If this is a surrogate pair, consume the next two bytes.
+                    result =
+                        valueLength === 0
+                            ? [decode_data_html[i] & ~BinTrieFlags.VALUE_LENGTH]
+                            : valueLength === 1
+                                ? [decode_data_html[++i]]
+                                : [decode_data_html[++i], decode_data_html[++i]];
+                    excess = 0;
+                    withoutSemicolon = cp !== CODE_POINTS.SEMICOLON;
+                }
+                if (valueLength === 0) {
+                    // If the value is zero-length, we're done.
+                    this._consume();
+                    break;
+                }
+            }
+        }
+        this._unconsume(excess);
+        if (withoutSemicolon && !this.preprocessor.endOfChunkHit) {
+            this._err(ERR.missingSemicolonAfterCharacterReference);
+        }
+        // We want to emit the error above on the code point after the entity.
+        // We always consume one code point too many in the loop, and we wait to
+        // unconsume it until after the error is emitted.
+        this._unconsume(1);
+        return result;
+    }
+    _isCharacterReferenceInAttribute() {
+        return (this.returnState === State.ATTRIBUTE_VALUE_DOUBLE_QUOTED ||
+            this.returnState === State.ATTRIBUTE_VALUE_SINGLE_QUOTED ||
+            this.returnState === State.ATTRIBUTE_VALUE_UNQUOTED);
+    }
+    _flushCodePointConsumedAsCharacterReference(cp) {
+        if (this._isCharacterReferenceInAttribute()) {
+            this.currentAttr.value += String.fromCodePoint(cp);
+        }
+        else {
+            this._emitCodePoint(cp);
+        }
+    }
+    // Calling states this way turns out to be much faster than any other approach.
+    _callState(cp) {
+        switch (this.state) {
+            case State.DATA: {
+                this._stateData(cp);
+                break;
+            }
+            case State.RCDATA: {
+                this._stateRcdata(cp);
+                break;
+            }
+            case State.RAWTEXT: {
+                this._stateRawtext(cp);
+                break;
+            }
+            case State.SCRIPT_DATA: {
+                this._stateScriptData(cp);
+                break;
+            }
+            case State.PLAINTEXT: {
+                this._statePlaintext(cp);
+                break;
+            }
+            case State.TAG_OPEN: {
+                this._stateTagOpen(cp);
+                break;
+            }
+            case State.END_TAG_OPEN: {
+                this._stateEndTagOpen(cp);
+                break;
+            }
+            case State.TAG_NAME: {
+                this._stateTagName(cp);
+                break;
+            }
+            case State.RCDATA_LESS_THAN_SIGN: {
+                this._stateRcdataLessThanSign(cp);
+                break;
+            }
+            case State.RCDATA_END_TAG_OPEN: {
+                this._stateRcdataEndTagOpen(cp);
+                break;
+            }
+            case State.RCDATA_END_TAG_NAME: {
+                this._stateRcdataEndTagName(cp);
+                break;
+            }
+            case State.RAWTEXT_LESS_THAN_SIGN: {
+                this._stateRawtextLessThanSign(cp);
+                break;
+            }
+            case State.RAWTEXT_END_TAG_OPEN: {
+                this._stateRawtextEndTagOpen(cp);
+                break;
+            }
+            case State.RAWTEXT_END_TAG_NAME: {
+                this._stateRawtextEndTagName(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_LESS_THAN_SIGN: {
+                this._stateScriptDataLessThanSign(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_END_TAG_OPEN: {
+                this._stateScriptDataEndTagOpen(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_END_TAG_NAME: {
+                this._stateScriptDataEndTagName(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPE_START: {
+                this._stateScriptDataEscapeStart(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPE_START_DASH: {
+                this._stateScriptDataEscapeStartDash(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPED: {
+                this._stateScriptDataEscaped(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPED_DASH: {
+                this._stateScriptDataEscapedDash(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPED_DASH_DASH: {
+                this._stateScriptDataEscapedDashDash(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPED_LESS_THAN_SIGN: {
+                this._stateScriptDataEscapedLessThanSign(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPED_END_TAG_OPEN: {
+                this._stateScriptDataEscapedEndTagOpen(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_ESCAPED_END_TAG_NAME: {
+                this._stateScriptDataEscapedEndTagName(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_DOUBLE_ESCAPE_START: {
+                this._stateScriptDataDoubleEscapeStart(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_DOUBLE_ESCAPED: {
+                this._stateScriptDataDoubleEscaped(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_DOUBLE_ESCAPED_DASH: {
+                this._stateScriptDataDoubleEscapedDash(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_DOUBLE_ESCAPED_DASH_DASH: {
+                this._stateScriptDataDoubleEscapedDashDash(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_DOUBLE_ESCAPED_LESS_THAN_SIGN: {
+                this._stateScriptDataDoubleEscapedLessThanSign(cp);
+                break;
+            }
+            case State.SCRIPT_DATA_DOUBLE_ESCAPE_END: {
+                this._stateScriptDataDoubleEscapeEnd(cp);
+                break;
+            }
+            case State.BEFORE_ATTRIBUTE_NAME: {
+                this._stateBeforeAttributeName(cp);
+                break;
+            }
+            case State.ATTRIBUTE_NAME: {
+                this._stateAttributeName(cp);
+                break;
+            }
+            case State.AFTER_ATTRIBUTE_NAME: {
+                this._stateAfterAttributeName(cp);
+                break;
+            }
+            case State.BEFORE_ATTRIBUTE_VALUE: {
+                this._stateBeforeAttributeValue(cp);
+                break;
+            }
+            case State.ATTRIBUTE_VALUE_DOUBLE_QUOTED: {
+                this._stateAttributeValueDoubleQuoted(cp);
+                break;
+            }
+            case State.ATTRIBUTE_VALUE_SINGLE_QUOTED: {
+                this._stateAttributeValueSingleQuoted(cp);
+                break;
+            }
+            case State.ATTRIBUTE_VALUE_UNQUOTED: {
+                this._stateAttributeValueUnquoted(cp);
+                break;
+            }
+            case State.AFTER_ATTRIBUTE_VALUE_QUOTED: {
+                this._stateAfterAttributeValueQuoted(cp);
+                break;
+            }
+            case State.SELF_CLOSING_START_TAG: {
+                this._stateSelfClosingStartTag(cp);
+                break;
+            }
+            case State.BOGUS_COMMENT: {
+                this._stateBogusComment(cp);
+                break;
+            }
+            case State.MARKUP_DECLARATION_OPEN: {
+                this._stateMarkupDeclarationOpen(cp);
+                break;
+            }
+            case State.COMMENT_START: {
+                this._stateCommentStart(cp);
+                break;
+            }
+            case State.COMMENT_START_DASH: {
+                this._stateCommentStartDash(cp);
+                break;
+            }
+            case State.COMMENT: {
+                this._stateComment(cp);
+                break;
+            }
+            case State.COMMENT_LESS_THAN_SIGN: {
+                this._stateCommentLessThanSign(cp);
+                break;
+            }
+            case State.COMMENT_LESS_THAN_SIGN_BANG: {
+                this._stateCommentLessThanSignBang(cp);
+                break;
+            }
+            case State.COMMENT_LESS_THAN_SIGN_BANG_DASH: {
+                this._stateCommentLessThanSignBangDash(cp);
+                break;
+            }
+            case State.COMMENT_LESS_THAN_SIGN_BANG_DASH_DASH: {
+                this._stateCommentLessThanSignBangDashDash(cp);
+                break;
+            }
+            case State.COMMENT_END_DASH: {
+                this._stateCommentEndDash(cp);
+                break;
+            }
+            case State.COMMENT_END: {
+                this._stateCommentEnd(cp);
+                break;
+            }
+            case State.COMMENT_END_BANG: {
+                this._stateCommentEndBang(cp);
+                break;
+            }
+            case State.DOCTYPE: {
+                this._stateDoctype(cp);
+                break;
+            }
+            case State.BEFORE_DOCTYPE_NAME: {
+                this._stateBeforeDoctypeName(cp);
+                break;
+            }
+            case State.DOCTYPE_NAME: {
+                this._stateDoctypeName(cp);
+                break;
+            }
+            case State.AFTER_DOCTYPE_NAME: {
+                this._stateAfterDoctypeName(cp);
+                break;
+            }
+            case State.AFTER_DOCTYPE_PUBLIC_KEYWORD: {
+                this._stateAfterDoctypePublicKeyword(cp);
+                break;
+            }
+            case State.BEFORE_DOCTYPE_PUBLIC_IDENTIFIER: {
+                this._stateBeforeDoctypePublicIdentifier(cp);
+                break;
+            }
+            case State.DOCTYPE_PUBLIC_IDENTIFIER_DOUBLE_QUOTED: {
+                this._stateDoctypePublicIdentifierDoubleQuoted(cp);
+                break;
+            }
+            case State.DOCTYPE_PUBLIC_IDENTIFIER_SINGLE_QUOTED: {
+                this._stateDoctypePublicIdentifierSingleQuoted(cp);
+                break;
+            }
+            case State.AFTER_DOCTYPE_PUBLIC_IDENTIFIER: {
+                this._stateAfterDoctypePublicIdentifier(cp);
+                break;
+            }
+            case State.BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS: {
+                this._stateBetweenDoctypePublicAndSystemIdentifiers(cp);
+                break;
+            }
+            case State.AFTER_DOCTYPE_SYSTEM_KEYWORD: {
+                this._stateAfterDoctypeSystemKeyword(cp);
+                break;
+            }
+            case State.BEFORE_DOCTYPE_SYSTEM_IDENTIFIER: {
+                this._stateBeforeDoctypeSystemIdentifier(cp);
+                break;
+            }
+            case State.DOCTYPE_SYSTEM_IDENTIFIER_DOUBLE_QUOTED: {
+                this._stateDoctypeSystemIdentifierDoubleQuoted(cp);
+                break;
+            }
+            case State.DOCTYPE_SYSTEM_IDENTIFIER_SINGLE_QUOTED: {
+                this._stateDoctypeSystemIdentifierSingleQuoted(cp);
+                break;
+            }
+            case State.AFTER_DOCTYPE_SYSTEM_IDENTIFIER: {
+                this._stateAfterDoctypeSystemIdentifier(cp);
+                break;
+            }
+            case State.BOGUS_DOCTYPE: {
+                this._stateBogusDoctype(cp);
+                break;
+            }
+            case State.CDATA_SECTION: {
+                this._stateCdataSection(cp);
+                break;
+            }
+            case State.CDATA_SECTION_BRACKET: {
+                this._stateCdataSectionBracket(cp);
+                break;
+            }
+            case State.CDATA_SECTION_END: {
+                this._stateCdataSectionEnd(cp);
+                break;
+            }
+            case State.CHARACTER_REFERENCE: {
+                this._stateCharacterReference(cp);
+                break;
+            }
+            case State.NAMED_CHARACTER_REFERENCE: {
+                this._stateNamedCharacterReference(cp);
+                break;
+            }
+            case State.AMBIGUOUS_AMPERSAND: {
+                this._stateAmbiguousAmpersand(cp);
+                break;
+            }
+            case State.NUMERIC_CHARACTER_REFERENCE: {
+                this._stateNumericCharacterReference(cp);
+                break;
+            }
+            case State.HEXADEMICAL_CHARACTER_REFERENCE_START: {
+                this._stateHexademicalCharacterReferenceStart(cp);
+                break;
+            }
+            case State.HEXADEMICAL_CHARACTER_REFERENCE: {
+                this._stateHexademicalCharacterReference(cp);
+                break;
+            }
+            case State.DECIMAL_CHARACTER_REFERENCE: {
+                this._stateDecimalCharacterReference(cp);
+                break;
+            }
+            case State.NUMERIC_CHARACTER_REFERENCE_END: {
+                this._stateNumericCharacterReferenceEnd(cp);
+                break;
+            }
+            default: {
+                throw new Error('Unknown state');
+            }
+        }
+    }
+    // State machine
+    // Data state
+    //------------------------------------------------------------------
+    _stateData(cp) {
+        switch (cp) {
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.TAG_OPEN;
+                break;
+            }
+            case CODE_POINTS.AMPERSAND: {
+                this.returnState = State.DATA;
+                this.state = State.CHARACTER_REFERENCE;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this._emitCodePoint(cp);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    //  RCDATA state
+    //------------------------------------------------------------------
+    _stateRcdata(cp) {
+        switch (cp) {
+            case CODE_POINTS.AMPERSAND: {
+                this.returnState = State.RCDATA;
+                this.state = State.CHARACTER_REFERENCE;
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.RCDATA_LESS_THAN_SIGN;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // RAWTEXT state
+    //------------------------------------------------------------------
+    _stateRawtext(cp) {
+        switch (cp) {
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.RAWTEXT_LESS_THAN_SIGN;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Script data state
+    //------------------------------------------------------------------
+    _stateScriptData(cp) {
+        switch (cp) {
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA_LESS_THAN_SIGN;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // PLAINTEXT state
+    //------------------------------------------------------------------
+    _statePlaintext(cp) {
+        switch (cp) {
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Tag open state
+    //------------------------------------------------------------------
+    _stateTagOpen(cp) {
+        if (isAsciiLetter(cp)) {
+            this._createStartTagToken();
+            this.state = State.TAG_NAME;
+            this._stateTagName(cp);
+        }
+        else
+            switch (cp) {
+                case CODE_POINTS.EXCLAMATION_MARK: {
+                    this.state = State.MARKUP_DECLARATION_OPEN;
+                    break;
+                }
+                case CODE_POINTS.SOLIDUS: {
+                    this.state = State.END_TAG_OPEN;
+                    break;
+                }
+                case CODE_POINTS.QUESTION_MARK: {
+                    this._err(ERR.unexpectedQuestionMarkInsteadOfTagName);
+                    this._createCommentToken(1);
+                    this.state = State.BOGUS_COMMENT;
+                    this._stateBogusComment(cp);
+                    break;
+                }
+                case CODE_POINTS.EOF: {
+                    this._err(ERR.eofBeforeTagName);
+                    this._emitChars('<');
+                    this._emitEOFToken();
+                    break;
+                }
+                default: {
+                    this._err(ERR.invalidFirstCharacterOfTagName);
+                    this._emitChars('<');
+                    this.state = State.DATA;
+                    this._stateData(cp);
+                }
+            }
+    }
+    // End tag open state
+    //------------------------------------------------------------------
+    _stateEndTagOpen(cp) {
+        if (isAsciiLetter(cp)) {
+            this._createEndTagToken();
+            this.state = State.TAG_NAME;
+            this._stateTagName(cp);
+        }
+        else
+            switch (cp) {
+                case CODE_POINTS.GREATER_THAN_SIGN: {
+                    this._err(ERR.missingEndTagName);
+                    this.state = State.DATA;
+                    break;
+                }
+                case CODE_POINTS.EOF: {
+                    this._err(ERR.eofBeforeTagName);
+                    this._emitChars('</');
+                    this._emitEOFToken();
+                    break;
+                }
+                default: {
+                    this._err(ERR.invalidFirstCharacterOfTagName);
+                    this._createCommentToken(2);
+                    this.state = State.BOGUS_COMMENT;
+                    this._stateBogusComment(cp);
+                }
+            }
+    }
+    // Tag name state
+    //------------------------------------------------------------------
+    _stateTagName(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this.state = State.BEFORE_ATTRIBUTE_NAME;
+                break;
+            }
+            case CODE_POINTS.SOLIDUS: {
+                this.state = State.SELF_CLOSING_START_TAG;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                this.emitCurrentTagToken();
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.tagName += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInTag);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.tagName += String.fromCodePoint(isAsciiUpper(cp) ? toAsciiLower(cp) : cp);
+            }
+        }
+    }
+    // RCDATA less-than sign state
+    //------------------------------------------------------------------
+    _stateRcdataLessThanSign(cp) {
+        if (cp === CODE_POINTS.SOLIDUS) {
+            this.state = State.RCDATA_END_TAG_OPEN;
+        }
+        else {
+            this._emitChars('<');
+            this.state = State.RCDATA;
+            this._stateRcdata(cp);
+        }
+    }
+    // RCDATA end tag open state
+    //------------------------------------------------------------------
+    _stateRcdataEndTagOpen(cp) {
+        if (isAsciiLetter(cp)) {
+            this.state = State.RCDATA_END_TAG_NAME;
+            this._stateRcdataEndTagName(cp);
+        }
+        else {
+            this._emitChars('</');
+            this.state = State.RCDATA;
+            this._stateRcdata(cp);
+        }
+    }
+    handleSpecialEndTag(_cp) {
+        if (!this.preprocessor.startsWith(this.lastStartTagName, false)) {
+            return !this._ensureHibernation();
+        }
+        this._createEndTagToken();
+        const token = this.currentToken;
+        token.tagName = this.lastStartTagName;
+        const cp = this.preprocessor.peek(this.lastStartTagName.length);
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this._advanceBy(this.lastStartTagName.length);
+                this.state = State.BEFORE_ATTRIBUTE_NAME;
+                return false;
+            }
+            case CODE_POINTS.SOLIDUS: {
+                this._advanceBy(this.lastStartTagName.length);
+                this.state = State.SELF_CLOSING_START_TAG;
+                return false;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._advanceBy(this.lastStartTagName.length);
+                this.emitCurrentTagToken();
+                this.state = State.DATA;
+                return false;
+            }
+            default: {
+                return !this._ensureHibernation();
+            }
+        }
+    }
+    // RCDATA end tag name state
+    //------------------------------------------------------------------
+    _stateRcdataEndTagName(cp) {
+        if (this.handleSpecialEndTag(cp)) {
+            this._emitChars('</');
+            this.state = State.RCDATA;
+            this._stateRcdata(cp);
+        }
+    }
+    // RAWTEXT less-than sign state
+    //------------------------------------------------------------------
+    _stateRawtextLessThanSign(cp) {
+        if (cp === CODE_POINTS.SOLIDUS) {
+            this.state = State.RAWTEXT_END_TAG_OPEN;
+        }
+        else {
+            this._emitChars('<');
+            this.state = State.RAWTEXT;
+            this._stateRawtext(cp);
+        }
+    }
+    // RAWTEXT end tag open state
+    //------------------------------------------------------------------
+    _stateRawtextEndTagOpen(cp) {
+        if (isAsciiLetter(cp)) {
+            this.state = State.RAWTEXT_END_TAG_NAME;
+            this._stateRawtextEndTagName(cp);
+        }
+        else {
+            this._emitChars('</');
+            this.state = State.RAWTEXT;
+            this._stateRawtext(cp);
+        }
+    }
+    // RAWTEXT end tag name state
+    //------------------------------------------------------------------
+    _stateRawtextEndTagName(cp) {
+        if (this.handleSpecialEndTag(cp)) {
+            this._emitChars('</');
+            this.state = State.RAWTEXT;
+            this._stateRawtext(cp);
+        }
+    }
+    // Script data less-than sign state
+    //------------------------------------------------------------------
+    _stateScriptDataLessThanSign(cp) {
+        switch (cp) {
+            case CODE_POINTS.SOLIDUS: {
+                this.state = State.SCRIPT_DATA_END_TAG_OPEN;
+                break;
+            }
+            case CODE_POINTS.EXCLAMATION_MARK: {
+                this.state = State.SCRIPT_DATA_ESCAPE_START;
+                this._emitChars('<!');
+                break;
+            }
+            default: {
+                this._emitChars('<');
+                this.state = State.SCRIPT_DATA;
+                this._stateScriptData(cp);
+            }
+        }
+    }
+    // Script data end tag open state
+    //------------------------------------------------------------------
+    _stateScriptDataEndTagOpen(cp) {
+        if (isAsciiLetter(cp)) {
+            this.state = State.SCRIPT_DATA_END_TAG_NAME;
+            this._stateScriptDataEndTagName(cp);
+        }
+        else {
+            this._emitChars('</');
+            this.state = State.SCRIPT_DATA;
+            this._stateScriptData(cp);
+        }
+    }
+    // Script data end tag name state
+    //------------------------------------------------------------------
+    _stateScriptDataEndTagName(cp) {
+        if (this.handleSpecialEndTag(cp)) {
+            this._emitChars('</');
+            this.state = State.SCRIPT_DATA;
+            this._stateScriptData(cp);
+        }
+    }
+    // Script data escape start state
+    //------------------------------------------------------------------
+    _stateScriptDataEscapeStart(cp) {
+        if (cp === CODE_POINTS.HYPHEN_MINUS) {
+            this.state = State.SCRIPT_DATA_ESCAPE_START_DASH;
+            this._emitChars('-');
+        }
+        else {
+            this.state = State.SCRIPT_DATA;
+            this._stateScriptData(cp);
+        }
+    }
+    // Script data escape start dash state
+    //------------------------------------------------------------------
+    _stateScriptDataEscapeStartDash(cp) {
+        if (cp === CODE_POINTS.HYPHEN_MINUS) {
+            this.state = State.SCRIPT_DATA_ESCAPED_DASH_DASH;
+            this._emitChars('-');
+        }
+        else {
+            this.state = State.SCRIPT_DATA;
+            this._stateScriptData(cp);
+        }
+    }
+    // Script data escaped state
+    //------------------------------------------------------------------
+    _stateScriptDataEscaped(cp) {
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.SCRIPT_DATA_ESCAPED_DASH;
+                this._emitChars('-');
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA_ESCAPED_LESS_THAN_SIGN;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInScriptHtmlCommentLikeText);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Script data escaped dash state
+    //------------------------------------------------------------------
+    _stateScriptDataEscapedDash(cp) {
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.SCRIPT_DATA_ESCAPED_DASH_DASH;
+                this._emitChars('-');
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA_ESCAPED_LESS_THAN_SIGN;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.state = State.SCRIPT_DATA_ESCAPED;
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInScriptHtmlCommentLikeText);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this.state = State.SCRIPT_DATA_ESCAPED;
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Script data escaped dash dash state
+    //------------------------------------------------------------------
+    _stateScriptDataEscapedDashDash(cp) {
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this._emitChars('-');
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA_ESCAPED_LESS_THAN_SIGN;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA;
+                this._emitChars('>');
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.state = State.SCRIPT_DATA_ESCAPED;
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInScriptHtmlCommentLikeText);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this.state = State.SCRIPT_DATA_ESCAPED;
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Script data escaped less-than sign state
+    //------------------------------------------------------------------
+    _stateScriptDataEscapedLessThanSign(cp) {
+        if (cp === CODE_POINTS.SOLIDUS) {
+            this.state = State.SCRIPT_DATA_ESCAPED_END_TAG_OPEN;
+        }
+        else if (isAsciiLetter(cp)) {
+            this._emitChars('<');
+            this.state = State.SCRIPT_DATA_DOUBLE_ESCAPE_START;
+            this._stateScriptDataDoubleEscapeStart(cp);
+        }
+        else {
+            this._emitChars('<');
+            this.state = State.SCRIPT_DATA_ESCAPED;
+            this._stateScriptDataEscaped(cp);
+        }
+    }
+    // Script data escaped end tag open state
+    //------------------------------------------------------------------
+    _stateScriptDataEscapedEndTagOpen(cp) {
+        if (isAsciiLetter(cp)) {
+            this.state = State.SCRIPT_DATA_ESCAPED_END_TAG_NAME;
+            this._stateScriptDataEscapedEndTagName(cp);
+        }
+        else {
+            this._emitChars('</');
+            this.state = State.SCRIPT_DATA_ESCAPED;
+            this._stateScriptDataEscaped(cp);
+        }
+    }
+    // Script data escaped end tag name state
+    //------------------------------------------------------------------
+    _stateScriptDataEscapedEndTagName(cp) {
+        if (this.handleSpecialEndTag(cp)) {
+            this._emitChars('</');
+            this.state = State.SCRIPT_DATA_ESCAPED;
+            this._stateScriptDataEscaped(cp);
+        }
+    }
+    // Script data double escape start state
+    //------------------------------------------------------------------
+    _stateScriptDataDoubleEscapeStart(cp) {
+        if (this.preprocessor.startsWith(SEQUENCES.SCRIPT, false) &&
+            isScriptDataDoubleEscapeSequenceEnd(this.preprocessor.peek(SEQUENCES.SCRIPT.length))) {
+            this._emitCodePoint(cp);
+            for (let i = 0; i < SEQUENCES.SCRIPT.length; i++) {
+                this._emitCodePoint(this._consume());
+            }
+            this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED;
+        }
+        else if (!this._ensureHibernation()) {
+            this.state = State.SCRIPT_DATA_ESCAPED;
+            this._stateScriptDataEscaped(cp);
+        }
+    }
+    // Script data double escaped state
+    //------------------------------------------------------------------
+    _stateScriptDataDoubleEscaped(cp) {
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED_DASH;
+                this._emitChars('-');
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED_LESS_THAN_SIGN;
+                this._emitChars('<');
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInScriptHtmlCommentLikeText);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Script data double escaped dash state
+    //------------------------------------------------------------------
+    _stateScriptDataDoubleEscapedDash(cp) {
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED_DASH_DASH;
+                this._emitChars('-');
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED_LESS_THAN_SIGN;
+                this._emitChars('<');
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED;
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInScriptHtmlCommentLikeText);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED;
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Script data double escaped dash dash state
+    //------------------------------------------------------------------
+    _stateScriptDataDoubleEscapedDashDash(cp) {
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this._emitChars('-');
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED_LESS_THAN_SIGN;
+                this._emitChars('<');
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.SCRIPT_DATA;
+                this._emitChars('>');
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED;
+                this._emitChars(REPLACEMENT_CHARACTER);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInScriptHtmlCommentLikeText);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED;
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // Script data double escaped less-than sign state
+    //------------------------------------------------------------------
+    _stateScriptDataDoubleEscapedLessThanSign(cp) {
+        if (cp === CODE_POINTS.SOLIDUS) {
+            this.state = State.SCRIPT_DATA_DOUBLE_ESCAPE_END;
+            this._emitChars('/');
+        }
+        else {
+            this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED;
+            this._stateScriptDataDoubleEscaped(cp);
+        }
+    }
+    // Script data double escape end state
+    //------------------------------------------------------------------
+    _stateScriptDataDoubleEscapeEnd(cp) {
+        if (this.preprocessor.startsWith(SEQUENCES.SCRIPT, false) &&
+            isScriptDataDoubleEscapeSequenceEnd(this.preprocessor.peek(SEQUENCES.SCRIPT.length))) {
+            this._emitCodePoint(cp);
+            for (let i = 0; i < SEQUENCES.SCRIPT.length; i++) {
+                this._emitCodePoint(this._consume());
+            }
+            this.state = State.SCRIPT_DATA_ESCAPED;
+        }
+        else if (!this._ensureHibernation()) {
+            this.state = State.SCRIPT_DATA_DOUBLE_ESCAPED;
+            this._stateScriptDataDoubleEscaped(cp);
+        }
+    }
+    // Before attribute name state
+    //------------------------------------------------------------------
+    _stateBeforeAttributeName(cp) {
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.SOLIDUS:
+            case CODE_POINTS.GREATER_THAN_SIGN:
+            case CODE_POINTS.EOF: {
+                this.state = State.AFTER_ATTRIBUTE_NAME;
+                this._stateAfterAttributeName(cp);
+                break;
+            }
+            case CODE_POINTS.EQUALS_SIGN: {
+                this._err(ERR.unexpectedEqualsSignBeforeAttributeName);
+                this._createAttr('=');
+                this.state = State.ATTRIBUTE_NAME;
+                break;
+            }
+            default: {
+                this._createAttr('');
+                this.state = State.ATTRIBUTE_NAME;
+                this._stateAttributeName(cp);
+            }
+        }
+    }
+    // Attribute name state
+    //------------------------------------------------------------------
+    _stateAttributeName(cp) {
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED:
+            case CODE_POINTS.SOLIDUS:
+            case CODE_POINTS.GREATER_THAN_SIGN:
+            case CODE_POINTS.EOF: {
+                this._leaveAttrName();
+                this.state = State.AFTER_ATTRIBUTE_NAME;
+                this._stateAfterAttributeName(cp);
+                break;
+            }
+            case CODE_POINTS.EQUALS_SIGN: {
+                this._leaveAttrName();
+                this.state = State.BEFORE_ATTRIBUTE_VALUE;
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK:
+            case CODE_POINTS.APOSTROPHE:
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                this._err(ERR.unexpectedCharacterInAttributeName);
+                this.currentAttr.name += String.fromCodePoint(cp);
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.currentAttr.name += REPLACEMENT_CHARACTER;
+                break;
+            }
+            default: {
+                this.currentAttr.name += String.fromCodePoint(isAsciiUpper(cp) ? toAsciiLower(cp) : cp);
+            }
+        }
+    }
+    // After attribute name state
+    //------------------------------------------------------------------
+    _stateAfterAttributeName(cp) {
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.SOLIDUS: {
+                this.state = State.SELF_CLOSING_START_TAG;
+                break;
+            }
+            case CODE_POINTS.EQUALS_SIGN: {
+                this.state = State.BEFORE_ATTRIBUTE_VALUE;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                this.emitCurrentTagToken();
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInTag);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._createAttr('');
+                this.state = State.ATTRIBUTE_NAME;
+                this._stateAttributeName(cp);
+            }
+        }
+    }
+    // Before attribute value state
+    //------------------------------------------------------------------
+    _stateBeforeAttributeValue(cp) {
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK: {
+                this.state = State.ATTRIBUTE_VALUE_DOUBLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.APOSTROPHE: {
+                this.state = State.ATTRIBUTE_VALUE_SINGLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.missingAttributeValue);
+                this.state = State.DATA;
+                this.emitCurrentTagToken();
+                break;
+            }
+            default: {
+                this.state = State.ATTRIBUTE_VALUE_UNQUOTED;
+                this._stateAttributeValueUnquoted(cp);
+            }
+        }
+    }
+    // Attribute value (double-quoted) state
+    //------------------------------------------------------------------
+    _stateAttributeValueDoubleQuoted(cp) {
+        switch (cp) {
+            case CODE_POINTS.QUOTATION_MARK: {
+                this.state = State.AFTER_ATTRIBUTE_VALUE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.AMPERSAND: {
+                this.returnState = State.ATTRIBUTE_VALUE_DOUBLE_QUOTED;
+                this.state = State.CHARACTER_REFERENCE;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.currentAttr.value += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInTag);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this.currentAttr.value += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // Attribute value (single-quoted) state
+    //------------------------------------------------------------------
+    _stateAttributeValueSingleQuoted(cp) {
+        switch (cp) {
+            case CODE_POINTS.APOSTROPHE: {
+                this.state = State.AFTER_ATTRIBUTE_VALUE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.AMPERSAND: {
+                this.returnState = State.ATTRIBUTE_VALUE_SINGLE_QUOTED;
+                this.state = State.CHARACTER_REFERENCE;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.currentAttr.value += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInTag);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this.currentAttr.value += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // Attribute value (unquoted) state
+    //------------------------------------------------------------------
+    _stateAttributeValueUnquoted(cp) {
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this._leaveAttrValue();
+                this.state = State.BEFORE_ATTRIBUTE_NAME;
+                break;
+            }
+            case CODE_POINTS.AMPERSAND: {
+                this.returnState = State.ATTRIBUTE_VALUE_UNQUOTED;
+                this.state = State.CHARACTER_REFERENCE;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._leaveAttrValue();
+                this.state = State.DATA;
+                this.emitCurrentTagToken();
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                this.currentAttr.value += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK:
+            case CODE_POINTS.APOSTROPHE:
+            case CODE_POINTS.LESS_THAN_SIGN:
+            case CODE_POINTS.EQUALS_SIGN:
+            case CODE_POINTS.GRAVE_ACCENT: {
+                this._err(ERR.unexpectedCharacterInUnquotedAttributeValue);
+                this.currentAttr.value += String.fromCodePoint(cp);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInTag);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this.currentAttr.value += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // After attribute value (quoted) state
+    //------------------------------------------------------------------
+    _stateAfterAttributeValueQuoted(cp) {
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this._leaveAttrValue();
+                this.state = State.BEFORE_ATTRIBUTE_NAME;
+                break;
+            }
+            case CODE_POINTS.SOLIDUS: {
+                this._leaveAttrValue();
+                this.state = State.SELF_CLOSING_START_TAG;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._leaveAttrValue();
+                this.state = State.DATA;
+                this.emitCurrentTagToken();
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInTag);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingWhitespaceBetweenAttributes);
+                this.state = State.BEFORE_ATTRIBUTE_NAME;
+                this._stateBeforeAttributeName(cp);
+            }
+        }
+    }
+    // Self-closing start tag state
+    //------------------------------------------------------------------
+    _stateSelfClosingStartTag(cp) {
+        switch (cp) {
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                const token = this.currentToken;
+                token.selfClosing = true;
+                this.state = State.DATA;
+                this.emitCurrentTagToken();
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInTag);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.unexpectedSolidusInTag);
+                this.state = State.BEFORE_ATTRIBUTE_NAME;
+                this._stateBeforeAttributeName(cp);
+            }
+        }
+    }
+    // Bogus comment state
+    //------------------------------------------------------------------
+    _stateBogusComment(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                this.emitCurrentComment(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this.emitCurrentComment(token);
+                this._emitEOFToken();
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.data += REPLACEMENT_CHARACTER;
+                break;
+            }
+            default: {
+                token.data += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // Markup declaration open state
+    //------------------------------------------------------------------
+    _stateMarkupDeclarationOpen(cp) {
+        if (this._consumeSequenceIfMatch(SEQUENCES.DASH_DASH, true)) {
+            this._createCommentToken(SEQUENCES.DASH_DASH.length + 1);
+            this.state = State.COMMENT_START;
+        }
+        else if (this._consumeSequenceIfMatch(SEQUENCES.DOCTYPE, false)) {
+            // NOTE: Doctypes tokens are created without fixed offsets. We keep track of the moment a doctype *might* start here.
+            this.currentLocation = this.getCurrentLocation(SEQUENCES.DOCTYPE.length + 1);
+            this.state = State.DOCTYPE;
+        }
+        else if (this._consumeSequenceIfMatch(SEQUENCES.CDATA_START, true)) {
+            if (this.inForeignNode) {
+                this.state = State.CDATA_SECTION;
+            }
+            else {
+                this._err(ERR.cdataInHtmlContent);
+                this._createCommentToken(SEQUENCES.CDATA_START.length + 1);
+                this.currentToken.data = '[CDATA[';
+                this.state = State.BOGUS_COMMENT;
+            }
+        }
+        //NOTE: Sequence lookups can be abrupted by hibernation. In that case, lookup
+        //results are no longer valid and we will need to start over.
+        else if (!this._ensureHibernation()) {
+            this._err(ERR.incorrectlyOpenedComment);
+            this._createCommentToken(2);
+            this.state = State.BOGUS_COMMENT;
+            this._stateBogusComment(cp);
+        }
+    }
+    // Comment start state
+    //------------------------------------------------------------------
+    _stateCommentStart(cp) {
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.COMMENT_START_DASH;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.abruptClosingOfEmptyComment);
+                this.state = State.DATA;
+                const token = this.currentToken;
+                this.emitCurrentComment(token);
+                break;
+            }
+            default: {
+                this.state = State.COMMENT;
+                this._stateComment(cp);
+            }
+        }
+    }
+    // Comment start dash state
+    //------------------------------------------------------------------
+    _stateCommentStartDash(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.COMMENT_END;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.abruptClosingOfEmptyComment);
+                this.state = State.DATA;
+                this.emitCurrentComment(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInComment);
+                this.emitCurrentComment(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.data += '-';
+                this.state = State.COMMENT;
+                this._stateComment(cp);
+            }
+        }
+    }
+    // Comment state
+    //------------------------------------------------------------------
+    _stateComment(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.COMMENT_END_DASH;
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                token.data += '<';
+                this.state = State.COMMENT_LESS_THAN_SIGN;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.data += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInComment);
+                this.emitCurrentComment(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.data += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // Comment less-than sign state
+    //------------------------------------------------------------------
+    _stateCommentLessThanSign(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.EXCLAMATION_MARK: {
+                token.data += '!';
+                this.state = State.COMMENT_LESS_THAN_SIGN_BANG;
+                break;
+            }
+            case CODE_POINTS.LESS_THAN_SIGN: {
+                token.data += '<';
+                break;
+            }
+            default: {
+                this.state = State.COMMENT;
+                this._stateComment(cp);
+            }
+        }
+    }
+    // Comment less-than sign bang state
+    //------------------------------------------------------------------
+    _stateCommentLessThanSignBang(cp) {
+        if (cp === CODE_POINTS.HYPHEN_MINUS) {
+            this.state = State.COMMENT_LESS_THAN_SIGN_BANG_DASH;
+        }
+        else {
+            this.state = State.COMMENT;
+            this._stateComment(cp);
+        }
+    }
+    // Comment less-than sign bang dash state
+    //------------------------------------------------------------------
+    _stateCommentLessThanSignBangDash(cp) {
+        if (cp === CODE_POINTS.HYPHEN_MINUS) {
+            this.state = State.COMMENT_LESS_THAN_SIGN_BANG_DASH_DASH;
+        }
+        else {
+            this.state = State.COMMENT_END_DASH;
+            this._stateCommentEndDash(cp);
+        }
+    }
+    // Comment less-than sign bang dash dash state
+    //------------------------------------------------------------------
+    _stateCommentLessThanSignBangDashDash(cp) {
+        if (cp !== CODE_POINTS.GREATER_THAN_SIGN && cp !== CODE_POINTS.EOF) {
+            this._err(ERR.nestedComment);
+        }
+        this.state = State.COMMENT_END;
+        this._stateCommentEnd(cp);
+    }
+    // Comment end dash state
+    //------------------------------------------------------------------
+    _stateCommentEndDash(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                this.state = State.COMMENT_END;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInComment);
+                this.emitCurrentComment(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.data += '-';
+                this.state = State.COMMENT;
+                this._stateComment(cp);
+            }
+        }
+    }
+    // Comment end state
+    //------------------------------------------------------------------
+    _stateCommentEnd(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                this.emitCurrentComment(token);
+                break;
+            }
+            case CODE_POINTS.EXCLAMATION_MARK: {
+                this.state = State.COMMENT_END_BANG;
+                break;
+            }
+            case CODE_POINTS.HYPHEN_MINUS: {
+                token.data += '-';
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInComment);
+                this.emitCurrentComment(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.data += '--';
+                this.state = State.COMMENT;
+                this._stateComment(cp);
+            }
+        }
+    }
+    // Comment end bang state
+    //------------------------------------------------------------------
+    _stateCommentEndBang(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.HYPHEN_MINUS: {
+                token.data += '--!';
+                this.state = State.COMMENT_END_DASH;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.incorrectlyClosedComment);
+                this.state = State.DATA;
+                this.emitCurrentComment(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInComment);
+                this.emitCurrentComment(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.data += '--!';
+                this.state = State.COMMENT;
+                this._stateComment(cp);
+            }
+        }
+    }
+    // DOCTYPE state
+    //------------------------------------------------------------------
+    _stateDoctype(cp) {
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this.state = State.BEFORE_DOCTYPE_NAME;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.BEFORE_DOCTYPE_NAME;
+                this._stateBeforeDoctypeName(cp);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                this._createDoctypeToken(null);
+                const token = this.currentToken;
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingWhitespaceBeforeDoctypeName);
+                this.state = State.BEFORE_DOCTYPE_NAME;
+                this._stateBeforeDoctypeName(cp);
+            }
+        }
+    }
+    // Before DOCTYPE name state
+    //------------------------------------------------------------------
+    _stateBeforeDoctypeName(cp) {
+        if (isAsciiUpper(cp)) {
+            this._createDoctypeToken(String.fromCharCode(toAsciiLower(cp)));
+            this.state = State.DOCTYPE_NAME;
+        }
+        else
+            switch (cp) {
+                case CODE_POINTS.SPACE:
+                case CODE_POINTS.LINE_FEED:
+                case CODE_POINTS.TABULATION:
+                case CODE_POINTS.FORM_FEED: {
+                    // Ignore whitespace
+                    break;
+                }
+                case CODE_POINTS.NULL: {
+                    this._err(ERR.unexpectedNullCharacter);
+                    this._createDoctypeToken(REPLACEMENT_CHARACTER);
+                    this.state = State.DOCTYPE_NAME;
+                    break;
+                }
+                case CODE_POINTS.GREATER_THAN_SIGN: {
+                    this._err(ERR.missingDoctypeName);
+                    this._createDoctypeToken(null);
+                    const token = this.currentToken;
+                    token.forceQuirks = true;
+                    this.emitCurrentDoctype(token);
+                    this.state = State.DATA;
+                    break;
+                }
+                case CODE_POINTS.EOF: {
+                    this._err(ERR.eofInDoctype);
+                    this._createDoctypeToken(null);
+                    const token = this.currentToken;
+                    token.forceQuirks = true;
+                    this.emitCurrentDoctype(token);
+                    this._emitEOFToken();
+                    break;
+                }
+                default: {
+                    this._createDoctypeToken(String.fromCodePoint(cp));
+                    this.state = State.DOCTYPE_NAME;
+                }
+            }
+    }
+    // DOCTYPE name state
+    //------------------------------------------------------------------
+    _stateDoctypeName(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this.state = State.AFTER_DOCTYPE_NAME;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                this.emitCurrentDoctype(token);
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.name += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.name += String.fromCodePoint(isAsciiUpper(cp) ? toAsciiLower(cp) : cp);
+            }
+        }
+    }
+    // After DOCTYPE name state
+    //------------------------------------------------------------------
+    _stateAfterDoctypeName(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                this.emitCurrentDoctype(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                if (this._consumeSequenceIfMatch(SEQUENCES.PUBLIC, false)) {
+                    this.state = State.AFTER_DOCTYPE_PUBLIC_KEYWORD;
+                }
+                else if (this._consumeSequenceIfMatch(SEQUENCES.SYSTEM, false)) {
+                    this.state = State.AFTER_DOCTYPE_SYSTEM_KEYWORD;
+                }
+                //NOTE: sequence lookup can be abrupted by hibernation. In that case lookup
+                //results are no longer valid and we will need to start over.
+                else if (!this._ensureHibernation()) {
+                    this._err(ERR.invalidCharacterSequenceAfterDoctypeName);
+                    token.forceQuirks = true;
+                    this.state = State.BOGUS_DOCTYPE;
+                    this._stateBogusDoctype(cp);
+                }
+            }
+        }
+    }
+    // After DOCTYPE public keyword state
+    //------------------------------------------------------------------
+    _stateAfterDoctypePublicKeyword(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this.state = State.BEFORE_DOCTYPE_PUBLIC_IDENTIFIER;
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK: {
+                this._err(ERR.missingWhitespaceAfterDoctypePublicKeyword);
+                token.publicId = '';
+                this.state = State.DOCTYPE_PUBLIC_IDENTIFIER_DOUBLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.APOSTROPHE: {
+                this._err(ERR.missingWhitespaceAfterDoctypePublicKeyword);
+                token.publicId = '';
+                this.state = State.DOCTYPE_PUBLIC_IDENTIFIER_SINGLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.missingDoctypePublicIdentifier);
+                token.forceQuirks = true;
+                this.state = State.DATA;
+                this.emitCurrentDoctype(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingQuoteBeforeDoctypePublicIdentifier);
+                token.forceQuirks = true;
+                this.state = State.BOGUS_DOCTYPE;
+                this._stateBogusDoctype(cp);
+            }
+        }
+    }
+    // Before DOCTYPE public identifier state
+    //------------------------------------------------------------------
+    _stateBeforeDoctypePublicIdentifier(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK: {
+                token.publicId = '';
+                this.state = State.DOCTYPE_PUBLIC_IDENTIFIER_DOUBLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.APOSTROPHE: {
+                token.publicId = '';
+                this.state = State.DOCTYPE_PUBLIC_IDENTIFIER_SINGLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.missingDoctypePublicIdentifier);
+                token.forceQuirks = true;
+                this.state = State.DATA;
+                this.emitCurrentDoctype(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingQuoteBeforeDoctypePublicIdentifier);
+                token.forceQuirks = true;
+                this.state = State.BOGUS_DOCTYPE;
+                this._stateBogusDoctype(cp);
+            }
+        }
+    }
+    // DOCTYPE public identifier (double-quoted) state
+    //------------------------------------------------------------------
+    _stateDoctypePublicIdentifierDoubleQuoted(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.QUOTATION_MARK: {
+                this.state = State.AFTER_DOCTYPE_PUBLIC_IDENTIFIER;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.publicId += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.abruptDoctypePublicIdentifier);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.publicId += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // DOCTYPE public identifier (single-quoted) state
+    //------------------------------------------------------------------
+    _stateDoctypePublicIdentifierSingleQuoted(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.APOSTROPHE: {
+                this.state = State.AFTER_DOCTYPE_PUBLIC_IDENTIFIER;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.publicId += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.abruptDoctypePublicIdentifier);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.publicId += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // After DOCTYPE public identifier state
+    //------------------------------------------------------------------
+    _stateAfterDoctypePublicIdentifier(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this.state = State.BETWEEN_DOCTYPE_PUBLIC_AND_SYSTEM_IDENTIFIERS;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                this.emitCurrentDoctype(token);
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK: {
+                this._err(ERR.missingWhitespaceBetweenDoctypePublicAndSystemIdentifiers);
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_DOUBLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.APOSTROPHE: {
+                this._err(ERR.missingWhitespaceBetweenDoctypePublicAndSystemIdentifiers);
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_SINGLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.state = State.BOGUS_DOCTYPE;
+                this._stateBogusDoctype(cp);
+            }
+        }
+    }
+    // Between DOCTYPE public and system identifiers state
+    //------------------------------------------------------------------
+    _stateBetweenDoctypePublicAndSystemIdentifiers(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.emitCurrentDoctype(token);
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK: {
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_DOUBLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.APOSTROPHE: {
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_SINGLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.state = State.BOGUS_DOCTYPE;
+                this._stateBogusDoctype(cp);
+            }
+        }
+    }
+    // After DOCTYPE system keyword state
+    //------------------------------------------------------------------
+    _stateAfterDoctypeSystemKeyword(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                this.state = State.BEFORE_DOCTYPE_SYSTEM_IDENTIFIER;
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK: {
+                this._err(ERR.missingWhitespaceAfterDoctypeSystemKeyword);
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_DOUBLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.APOSTROPHE: {
+                this._err(ERR.missingWhitespaceAfterDoctypeSystemKeyword);
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_SINGLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.missingDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.state = State.DATA;
+                this.emitCurrentDoctype(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.state = State.BOGUS_DOCTYPE;
+                this._stateBogusDoctype(cp);
+            }
+        }
+    }
+    // Before DOCTYPE system identifier state
+    //------------------------------------------------------------------
+    _stateBeforeDoctypeSystemIdentifier(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.QUOTATION_MARK: {
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_DOUBLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.APOSTROPHE: {
+                token.systemId = '';
+                this.state = State.DOCTYPE_SYSTEM_IDENTIFIER_SINGLE_QUOTED;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.missingDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.state = State.DATA;
+                this.emitCurrentDoctype(token);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.state = State.BOGUS_DOCTYPE;
+                this._stateBogusDoctype(cp);
+            }
+        }
+    }
+    // DOCTYPE system identifier (double-quoted) state
+    //------------------------------------------------------------------
+    _stateDoctypeSystemIdentifierDoubleQuoted(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.QUOTATION_MARK: {
+                this.state = State.AFTER_DOCTYPE_SYSTEM_IDENTIFIER;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.systemId += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.abruptDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.systemId += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // DOCTYPE system identifier (single-quoted) state
+    //------------------------------------------------------------------
+    _stateDoctypeSystemIdentifierSingleQuoted(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.APOSTROPHE: {
+                this.state = State.AFTER_DOCTYPE_SYSTEM_IDENTIFIER;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                token.systemId += REPLACEMENT_CHARACTER;
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this._err(ERR.abruptDoctypeSystemIdentifier);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                token.systemId += String.fromCodePoint(cp);
+            }
+        }
+    }
+    // After DOCTYPE system identifier state
+    //------------------------------------------------------------------
+    _stateAfterDoctypeSystemIdentifier(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.SPACE:
+            case CODE_POINTS.LINE_FEED:
+            case CODE_POINTS.TABULATION:
+            case CODE_POINTS.FORM_FEED: {
+                // Ignore whitespace
+                break;
+            }
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.emitCurrentDoctype(token);
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInDoctype);
+                token.forceQuirks = true;
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._err(ERR.unexpectedCharacterAfterDoctypeSystemIdentifier);
+                this.state = State.BOGUS_DOCTYPE;
+                this._stateBogusDoctype(cp);
+            }
+        }
+    }
+    // Bogus DOCTYPE state
+    //------------------------------------------------------------------
+    _stateBogusDoctype(cp) {
+        const token = this.currentToken;
+        switch (cp) {
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.emitCurrentDoctype(token);
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.NULL: {
+                this._err(ERR.unexpectedNullCharacter);
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this.emitCurrentDoctype(token);
+                this._emitEOFToken();
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    // CDATA section state
+    //------------------------------------------------------------------
+    _stateCdataSection(cp) {
+        switch (cp) {
+            case CODE_POINTS.RIGHT_SQUARE_BRACKET: {
+                this.state = State.CDATA_SECTION_BRACKET;
+                break;
+            }
+            case CODE_POINTS.EOF: {
+                this._err(ERR.eofInCdata);
+                this._emitEOFToken();
+                break;
+            }
+            default: {
+                this._emitCodePoint(cp);
+            }
+        }
+    }
+    // CDATA section bracket state
+    //------------------------------------------------------------------
+    _stateCdataSectionBracket(cp) {
+        if (cp === CODE_POINTS.RIGHT_SQUARE_BRACKET) {
+            this.state = State.CDATA_SECTION_END;
+        }
+        else {
+            this._emitChars(']');
+            this.state = State.CDATA_SECTION;
+            this._stateCdataSection(cp);
+        }
+    }
+    // CDATA section end state
+    //------------------------------------------------------------------
+    _stateCdataSectionEnd(cp) {
+        switch (cp) {
+            case CODE_POINTS.GREATER_THAN_SIGN: {
+                this.state = State.DATA;
+                break;
+            }
+            case CODE_POINTS.RIGHT_SQUARE_BRACKET: {
+                this._emitChars(']');
+                break;
+            }
+            default: {
+                this._emitChars(']]');
+                this.state = State.CDATA_SECTION;
+                this._stateCdataSection(cp);
+            }
+        }
+    }
+    // Character reference state
+    //------------------------------------------------------------------
+    _stateCharacterReference(cp) {
+        if (cp === CODE_POINTS.NUMBER_SIGN) {
+            this.state = State.NUMERIC_CHARACTER_REFERENCE;
+        }
+        else if (tokenizer_isAsciiAlphaNumeric(cp)) {
+            this.state = State.NAMED_CHARACTER_REFERENCE;
+            this._stateNamedCharacterReference(cp);
+        }
+        else {
+            this._flushCodePointConsumedAsCharacterReference(CODE_POINTS.AMPERSAND);
+            this._reconsumeInState(this.returnState, cp);
+        }
+    }
+    // Named character reference state
+    //------------------------------------------------------------------
+    _stateNamedCharacterReference(cp) {
+        const matchResult = this._matchNamedCharacterReference(cp);
+        //NOTE: Matching can be abrupted by hibernation. In that case, match
+        //results are no longer valid and we will need to start over.
+        if (this._ensureHibernation()) {
+            // Stay in the state, try again.
+        }
+        else if (matchResult) {
+            for (let i = 0; i < matchResult.length; i++) {
+                this._flushCodePointConsumedAsCharacterReference(matchResult[i]);
+            }
+            this.state = this.returnState;
+        }
+        else {
+            this._flushCodePointConsumedAsCharacterReference(CODE_POINTS.AMPERSAND);
+            this.state = State.AMBIGUOUS_AMPERSAND;
+        }
+    }
+    // Ambiguos ampersand state
+    //------------------------------------------------------------------
+    _stateAmbiguousAmpersand(cp) {
+        if (tokenizer_isAsciiAlphaNumeric(cp)) {
+            this._flushCodePointConsumedAsCharacterReference(cp);
+        }
+        else {
+            if (cp === CODE_POINTS.SEMICOLON) {
+                this._err(ERR.unknownNamedCharacterReference);
+            }
+            this._reconsumeInState(this.returnState, cp);
+        }
+    }
+    // Numeric character reference state
+    //------------------------------------------------------------------
+    _stateNumericCharacterReference(cp) {
+        this.charRefCode = 0;
+        if (cp === CODE_POINTS.LATIN_SMALL_X || cp === CODE_POINTS.LATIN_CAPITAL_X) {
+            this.state = State.HEXADEMICAL_CHARACTER_REFERENCE_START;
+        }
+        // Inlined decimal character reference start state
+        else if (isAsciiDigit(cp)) {
+            this.state = State.DECIMAL_CHARACTER_REFERENCE;
+            this._stateDecimalCharacterReference(cp);
+        }
+        else {
+            this._err(ERR.absenceOfDigitsInNumericCharacterReference);
+            this._flushCodePointConsumedAsCharacterReference(CODE_POINTS.AMPERSAND);
+            this._flushCodePointConsumedAsCharacterReference(CODE_POINTS.NUMBER_SIGN);
+            this._reconsumeInState(this.returnState, cp);
+        }
+    }
+    // Hexademical character reference start state
+    //------------------------------------------------------------------
+    _stateHexademicalCharacterReferenceStart(cp) {
+        if (isAsciiHexDigit(cp)) {
+            this.state = State.HEXADEMICAL_CHARACTER_REFERENCE;
+            this._stateHexademicalCharacterReference(cp);
+        }
+        else {
+            this._err(ERR.absenceOfDigitsInNumericCharacterReference);
+            this._flushCodePointConsumedAsCharacterReference(CODE_POINTS.AMPERSAND);
+            this._flushCodePointConsumedAsCharacterReference(CODE_POINTS.NUMBER_SIGN);
+            this._unconsume(2);
+            this.state = this.returnState;
+        }
+    }
+    // Hexademical character reference state
+    //------------------------------------------------------------------
+    _stateHexademicalCharacterReference(cp) {
+        if (isAsciiUpperHexDigit(cp)) {
+            this.charRefCode = this.charRefCode * 16 + cp - 0x37;
+        }
+        else if (isAsciiLowerHexDigit(cp)) {
+            this.charRefCode = this.charRefCode * 16 + cp - 0x57;
+        }
+        else if (isAsciiDigit(cp)) {
+            this.charRefCode = this.charRefCode * 16 + cp - 0x30;
+        }
+        else if (cp === CODE_POINTS.SEMICOLON) {
+            this.state = State.NUMERIC_CHARACTER_REFERENCE_END;
+        }
+        else {
+            this._err(ERR.missingSemicolonAfterCharacterReference);
+            this.state = State.NUMERIC_CHARACTER_REFERENCE_END;
+            this._stateNumericCharacterReferenceEnd(cp);
+        }
+    }
+    // Decimal character reference state
+    //------------------------------------------------------------------
+    _stateDecimalCharacterReference(cp) {
+        if (isAsciiDigit(cp)) {
+            this.charRefCode = this.charRefCode * 10 + cp - 0x30;
+        }
+        else if (cp === CODE_POINTS.SEMICOLON) {
+            this.state = State.NUMERIC_CHARACTER_REFERENCE_END;
+        }
+        else {
+            this._err(ERR.missingSemicolonAfterCharacterReference);
+            this.state = State.NUMERIC_CHARACTER_REFERENCE_END;
+            this._stateNumericCharacterReferenceEnd(cp);
+        }
+    }
+    // Numeric character reference end state
+    //------------------------------------------------------------------
+    _stateNumericCharacterReferenceEnd(cp) {
+        if (this.charRefCode === CODE_POINTS.NULL) {
+            this._err(ERR.nullCharacterReference);
+            this.charRefCode = CODE_POINTS.REPLACEMENT_CHARACTER;
+        }
+        else if (this.charRefCode > 1114111) {
+            this._err(ERR.characterReferenceOutsideUnicodeRange);
+            this.charRefCode = CODE_POINTS.REPLACEMENT_CHARACTER;
+        }
+        else if (isSurrogate(this.charRefCode)) {
+            this._err(ERR.surrogateCharacterReference);
+            this.charRefCode = CODE_POINTS.REPLACEMENT_CHARACTER;
+        }
+        else if (isUndefinedCodePoint(this.charRefCode)) {
+            this._err(ERR.noncharacterCharacterReference);
+        }
+        else if (isControlCodePoint(this.charRefCode) || this.charRefCode === CODE_POINTS.CARRIAGE_RETURN) {
+            this._err(ERR.controlCharacterReference);
+            const replacement = C1_CONTROLS_REFERENCE_REPLACEMENTS.get(this.charRefCode);
+            if (replacement !== undefined) {
+                this.charRefCode = replacement;
+            }
+        }
+        this._flushCodePointConsumedAsCharacterReference(this.charRefCode);
+        this._reconsumeInState(this.returnState, cp);
+    }
+}
+//# sourceMappingURL=index.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/parser/open-element-stack.js
+
+//Element utils
+const IMPLICIT_END_TAG_REQUIRED = new Set([TAG_ID.DD, TAG_ID.DT, TAG_ID.LI, TAG_ID.OPTGROUP, TAG_ID.OPTION, TAG_ID.P, TAG_ID.RB, TAG_ID.RP, TAG_ID.RT, TAG_ID.RTC]);
+const IMPLICIT_END_TAG_REQUIRED_THOROUGHLY = new Set([
+    ...IMPLICIT_END_TAG_REQUIRED,
+    TAG_ID.CAPTION,
+    TAG_ID.COLGROUP,
+    TAG_ID.TBODY,
+    TAG_ID.TD,
+    TAG_ID.TFOOT,
+    TAG_ID.TH,
+    TAG_ID.THEAD,
+    TAG_ID.TR,
+]);
+const SCOPING_ELEMENT_NS = new Map([
+    [TAG_ID.APPLET, html_NS.HTML],
+    [TAG_ID.CAPTION, html_NS.HTML],
+    [TAG_ID.HTML, html_NS.HTML],
+    [TAG_ID.MARQUEE, html_NS.HTML],
+    [TAG_ID.OBJECT, html_NS.HTML],
+    [TAG_ID.TABLE, html_NS.HTML],
+    [TAG_ID.TD, html_NS.HTML],
+    [TAG_ID.TEMPLATE, html_NS.HTML],
+    [TAG_ID.TH, html_NS.HTML],
+    [TAG_ID.ANNOTATION_XML, html_NS.MATHML],
+    [TAG_ID.MI, html_NS.MATHML],
+    [TAG_ID.MN, html_NS.MATHML],
+    [TAG_ID.MO, html_NS.MATHML],
+    [TAG_ID.MS, html_NS.MATHML],
+    [TAG_ID.MTEXT, html_NS.MATHML],
+    [TAG_ID.DESC, html_NS.SVG],
+    [TAG_ID.FOREIGN_OBJECT, html_NS.SVG],
+    [TAG_ID.TITLE, html_NS.SVG],
+]);
+const NAMED_HEADERS = [TAG_ID.H1, TAG_ID.H2, TAG_ID.H3, TAG_ID.H4, TAG_ID.H5, TAG_ID.H6];
+const TABLE_ROW_CONTEXT = [TAG_ID.TR, TAG_ID.TEMPLATE, TAG_ID.HTML];
+const TABLE_BODY_CONTEXT = [TAG_ID.TBODY, TAG_ID.TFOOT, TAG_ID.THEAD, TAG_ID.TEMPLATE, TAG_ID.HTML];
+const TABLE_CONTEXT = [TAG_ID.TABLE, TAG_ID.TEMPLATE, TAG_ID.HTML];
+const TABLE_CELLS = [TAG_ID.TD, TAG_ID.TH];
+//Stack of open elements
+class OpenElementStack {
+    get currentTmplContentOrNode() {
+        return this._isInTemplate() ? this.treeAdapter.getTemplateContent(this.current) : this.current;
+    }
+    constructor(document, treeAdapter, handler) {
+        this.treeAdapter = treeAdapter;
+        this.handler = handler;
+        this.items = [];
+        this.tagIDs = [];
+        this.stackTop = -1;
+        this.tmplCount = 0;
+        this.currentTagId = TAG_ID.UNKNOWN;
+        this.current = document;
+    }
+    //Index of element
+    _indexOf(element) {
+        return this.items.lastIndexOf(element, this.stackTop);
+    }
+    //Update current element
+    _isInTemplate() {
+        return this.currentTagId === TAG_ID.TEMPLATE && this.treeAdapter.getNamespaceURI(this.current) === html_NS.HTML;
+    }
+    _updateCurrentElement() {
+        this.current = this.items[this.stackTop];
+        this.currentTagId = this.tagIDs[this.stackTop];
+    }
+    //Mutations
+    push(element, tagID) {
+        this.stackTop++;
+        this.items[this.stackTop] = element;
+        this.current = element;
+        this.tagIDs[this.stackTop] = tagID;
+        this.currentTagId = tagID;
+        if (this._isInTemplate()) {
+            this.tmplCount++;
+        }
+        this.handler.onItemPush(element, tagID, true);
+    }
+    pop() {
+        const popped = this.current;
+        if (this.tmplCount > 0 && this._isInTemplate()) {
+            this.tmplCount--;
+        }
+        this.stackTop--;
+        this._updateCurrentElement();
+        this.handler.onItemPop(popped, true);
+    }
+    replace(oldElement, newElement) {
+        const idx = this._indexOf(oldElement);
+        this.items[idx] = newElement;
+        if (idx === this.stackTop) {
+            this.current = newElement;
+        }
+    }
+    insertAfter(referenceElement, newElement, newElementID) {
+        const insertionIdx = this._indexOf(referenceElement) + 1;
+        this.items.splice(insertionIdx, 0, newElement);
+        this.tagIDs.splice(insertionIdx, 0, newElementID);
+        this.stackTop++;
+        if (insertionIdx === this.stackTop) {
+            this._updateCurrentElement();
+        }
+        this.handler.onItemPush(this.current, this.currentTagId, insertionIdx === this.stackTop);
+    }
+    popUntilTagNamePopped(tagName) {
+        let targetIdx = this.stackTop + 1;
+        do {
+            targetIdx = this.tagIDs.lastIndexOf(tagName, targetIdx - 1);
+        } while (targetIdx > 0 && this.treeAdapter.getNamespaceURI(this.items[targetIdx]) !== html_NS.HTML);
+        this.shortenToLength(targetIdx < 0 ? 0 : targetIdx);
+    }
+    shortenToLength(idx) {
+        while (this.stackTop >= idx) {
+            const popped = this.current;
+            if (this.tmplCount > 0 && this._isInTemplate()) {
+                this.tmplCount -= 1;
+            }
+            this.stackTop--;
+            this._updateCurrentElement();
+            this.handler.onItemPop(popped, this.stackTop < idx);
+        }
+    }
+    popUntilElementPopped(element) {
+        const idx = this._indexOf(element);
+        this.shortenToLength(idx < 0 ? 0 : idx);
+    }
+    popUntilPopped(tagNames, targetNS) {
+        const idx = this._indexOfTagNames(tagNames, targetNS);
+        this.shortenToLength(idx < 0 ? 0 : idx);
+    }
+    popUntilNumberedHeaderPopped() {
+        this.popUntilPopped(NAMED_HEADERS, html_NS.HTML);
+    }
+    popUntilTableCellPopped() {
+        this.popUntilPopped(TABLE_CELLS, html_NS.HTML);
+    }
+    popAllUpToHtmlElement() {
+        //NOTE: here we assume that the root <html> element is always first in the open element stack, so
+        //we perform this fast stack clean up.
+        this.tmplCount = 0;
+        this.shortenToLength(1);
+    }
+    _indexOfTagNames(tagNames, namespace) {
+        for (let i = this.stackTop; i >= 0; i--) {
+            if (tagNames.includes(this.tagIDs[i]) && this.treeAdapter.getNamespaceURI(this.items[i]) === namespace) {
+                return i;
+            }
+        }
+        return -1;
+    }
+    clearBackTo(tagNames, targetNS) {
+        const idx = this._indexOfTagNames(tagNames, targetNS);
+        this.shortenToLength(idx + 1);
+    }
+    clearBackToTableContext() {
+        this.clearBackTo(TABLE_CONTEXT, html_NS.HTML);
+    }
+    clearBackToTableBodyContext() {
+        this.clearBackTo(TABLE_BODY_CONTEXT, html_NS.HTML);
+    }
+    clearBackToTableRowContext() {
+        this.clearBackTo(TABLE_ROW_CONTEXT, html_NS.HTML);
+    }
+    remove(element) {
+        const idx = this._indexOf(element);
+        if (idx >= 0) {
+            if (idx === this.stackTop) {
+                this.pop();
+            }
+            else {
+                this.items.splice(idx, 1);
+                this.tagIDs.splice(idx, 1);
+                this.stackTop--;
+                this._updateCurrentElement();
+                this.handler.onItemPop(element, false);
+            }
+        }
+    }
+    //Search
+    tryPeekProperlyNestedBodyElement() {
+        //Properly nested <body> element (should be second element in stack).
+        return this.stackTop >= 1 && this.tagIDs[1] === TAG_ID.BODY ? this.items[1] : null;
+    }
+    contains(element) {
+        return this._indexOf(element) > -1;
+    }
+    getCommonAncestor(element) {
+        const elementIdx = this._indexOf(element) - 1;
+        return elementIdx >= 0 ? this.items[elementIdx] : null;
+    }
+    isRootHtmlElementCurrent() {
+        return this.stackTop === 0 && this.tagIDs[0] === TAG_ID.HTML;
+    }
+    //Element in scope
+    hasInScope(tagName) {
+        for (let i = this.stackTop; i >= 0; i--) {
+            const tn = this.tagIDs[i];
+            const ns = this.treeAdapter.getNamespaceURI(this.items[i]);
+            if (tn === tagName && ns === html_NS.HTML) {
+                return true;
+            }
+            if (SCOPING_ELEMENT_NS.get(tn) === ns) {
+                return false;
+            }
+        }
+        return true;
+    }
+    hasNumberedHeaderInScope() {
+        for (let i = this.stackTop; i >= 0; i--) {
+            const tn = this.tagIDs[i];
+            const ns = this.treeAdapter.getNamespaceURI(this.items[i]);
+            if (isNumberedHeader(tn) && ns === html_NS.HTML) {
+                return true;
+            }
+            if (SCOPING_ELEMENT_NS.get(tn) === ns) {
+                return false;
+            }
+        }
+        return true;
+    }
+    hasInListItemScope(tagName) {
+        for (let i = this.stackTop; i >= 0; i--) {
+            const tn = this.tagIDs[i];
+            const ns = this.treeAdapter.getNamespaceURI(this.items[i]);
+            if (tn === tagName && ns === html_NS.HTML) {
+                return true;
+            }
+            if (((tn === TAG_ID.UL || tn === TAG_ID.OL) && ns === html_NS.HTML) || SCOPING_ELEMENT_NS.get(tn) === ns) {
+                return false;
+            }
+        }
+        return true;
+    }
+    hasInButtonScope(tagName) {
+        for (let i = this.stackTop; i >= 0; i--) {
+            const tn = this.tagIDs[i];
+            const ns = this.treeAdapter.getNamespaceURI(this.items[i]);
+            if (tn === tagName && ns === html_NS.HTML) {
+                return true;
+            }
+            if ((tn === TAG_ID.BUTTON && ns === html_NS.HTML) || SCOPING_ELEMENT_NS.get(tn) === ns) {
+                return false;
+            }
+        }
+        return true;
+    }
+    hasInTableScope(tagName) {
+        for (let i = this.stackTop; i >= 0; i--) {
+            const tn = this.tagIDs[i];
+            const ns = this.treeAdapter.getNamespaceURI(this.items[i]);
+            if (ns !== html_NS.HTML) {
+                continue;
+            }
+            if (tn === tagName) {
+                return true;
+            }
+            if (tn === TAG_ID.TABLE || tn === TAG_ID.TEMPLATE || tn === TAG_ID.HTML) {
+                return false;
+            }
+        }
+        return true;
+    }
+    hasTableBodyContextInTableScope() {
+        for (let i = this.stackTop; i >= 0; i--) {
+            const tn = this.tagIDs[i];
+            const ns = this.treeAdapter.getNamespaceURI(this.items[i]);
+            if (ns !== html_NS.HTML) {
+                continue;
+            }
+            if (tn === TAG_ID.TBODY || tn === TAG_ID.THEAD || tn === TAG_ID.TFOOT) {
+                return true;
+            }
+            if (tn === TAG_ID.TABLE || tn === TAG_ID.HTML) {
+                return false;
+            }
+        }
+        return true;
+    }
+    hasInSelectScope(tagName) {
+        for (let i = this.stackTop; i >= 0; i--) {
+            const tn = this.tagIDs[i];
+            const ns = this.treeAdapter.getNamespaceURI(this.items[i]);
+            if (ns !== html_NS.HTML) {
+                continue;
+            }
+            if (tn === tagName) {
+                return true;
+            }
+            if (tn !== TAG_ID.OPTION && tn !== TAG_ID.OPTGROUP) {
+                return false;
+            }
+        }
+        return true;
+    }
+    //Implied end tags
+    generateImpliedEndTags() {
+        while (IMPLICIT_END_TAG_REQUIRED.has(this.currentTagId)) {
+            this.pop();
+        }
+    }
+    generateImpliedEndTagsThoroughly() {
+        while (IMPLICIT_END_TAG_REQUIRED_THOROUGHLY.has(this.currentTagId)) {
+            this.pop();
+        }
+    }
+    generateImpliedEndTagsWithExclusion(exclusionId) {
+        while (this.currentTagId !== exclusionId && IMPLICIT_END_TAG_REQUIRED_THOROUGHLY.has(this.currentTagId)) {
+            this.pop();
+        }
+    }
+}
+//# sourceMappingURL=open-element-stack.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/parser/formatting-element-list.js
+//Const
+const NOAH_ARK_CAPACITY = 3;
+var EntryType;
+(function (EntryType) {
+    EntryType[EntryType["Marker"] = 0] = "Marker";
+    EntryType[EntryType["Element"] = 1] = "Element";
+})(EntryType = EntryType || (EntryType = {}));
+const MARKER = { type: EntryType.Marker };
+//List of formatting elements
+class FormattingElementList {
+    constructor(treeAdapter) {
+        this.treeAdapter = treeAdapter;
+        this.entries = [];
+        this.bookmark = null;
+    }
+    //Noah Ark's condition
+    //OPTIMIZATION: at first we try to find possible candidates for exclusion using
+    //lightweight heuristics without thorough attributes check.
+    _getNoahArkConditionCandidates(newElement, neAttrs) {
+        const candidates = [];
+        const neAttrsLength = neAttrs.length;
+        const neTagName = this.treeAdapter.getTagName(newElement);
+        const neNamespaceURI = this.treeAdapter.getNamespaceURI(newElement);
+        for (let i = 0; i < this.entries.length; i++) {
+            const entry = this.entries[i];
+            if (entry.type === EntryType.Marker) {
+                break;
+            }
+            const { element } = entry;
+            if (this.treeAdapter.getTagName(element) === neTagName &&
+                this.treeAdapter.getNamespaceURI(element) === neNamespaceURI) {
+                const elementAttrs = this.treeAdapter.getAttrList(element);
+                if (elementAttrs.length === neAttrsLength) {
+                    candidates.push({ idx: i, attrs: elementAttrs });
+                }
+            }
+        }
+        return candidates;
+    }
+    _ensureNoahArkCondition(newElement) {
+        if (this.entries.length < NOAH_ARK_CAPACITY)
+            return;
+        const neAttrs = this.treeAdapter.getAttrList(newElement);
+        const candidates = this._getNoahArkConditionCandidates(newElement, neAttrs);
+        if (candidates.length < NOAH_ARK_CAPACITY)
+            return;
+        //NOTE: build attrs map for the new element, so we can perform fast lookups
+        const neAttrsMap = new Map(neAttrs.map((neAttr) => [neAttr.name, neAttr.value]));
+        let validCandidates = 0;
+        //NOTE: remove bottommost candidates, until Noah's Ark condition will not be met
+        for (let i = 0; i < candidates.length; i++) {
+            const candidate = candidates[i];
+            // We know that `candidate.attrs.length === neAttrs.length`
+            if (candidate.attrs.every((cAttr) => neAttrsMap.get(cAttr.name) === cAttr.value)) {
+                validCandidates += 1;
+                if (validCandidates >= NOAH_ARK_CAPACITY) {
+                    this.entries.splice(candidate.idx, 1);
+                }
+            }
+        }
+    }
+    //Mutations
+    insertMarker() {
+        this.entries.unshift(MARKER);
+    }
+    pushElement(element, token) {
+        this._ensureNoahArkCondition(element);
+        this.entries.unshift({
+            type: EntryType.Element,
+            element,
+            token,
+        });
+    }
+    insertElementAfterBookmark(element, token) {
+        const bookmarkIdx = this.entries.indexOf(this.bookmark);
+        this.entries.splice(bookmarkIdx, 0, {
+            type: EntryType.Element,
+            element,
+            token,
+        });
+    }
+    removeEntry(entry) {
+        const entryIndex = this.entries.indexOf(entry);
+        if (entryIndex >= 0) {
+            this.entries.splice(entryIndex, 1);
+        }
+    }
+    /**
+     * Clears the list of formatting elements up to the last marker.
+     *
+     * @see https://html.spec.whatwg.org/multipage/parsing.html#clear-the-list-of-active-formatting-elements-up-to-the-last-marker
+     */
+    clearToLastMarker() {
+        const markerIdx = this.entries.indexOf(MARKER);
+        if (markerIdx >= 0) {
+            this.entries.splice(0, markerIdx + 1);
+        }
+        else {
+            this.entries.length = 0;
+        }
+    }
+    //Search
+    getElementEntryInScopeWithTagName(tagName) {
+        const entry = this.entries.find((entry) => entry.type === EntryType.Marker || this.treeAdapter.getTagName(entry.element) === tagName);
+        return entry && entry.type === EntryType.Element ? entry : null;
+    }
+    getElementEntry(element) {
+        return this.entries.find((entry) => entry.type === EntryType.Element && entry.element === element);
+    }
+}
+//# sourceMappingURL=formatting-element-list.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/tree-adapters/default.js
+
+function createTextNode(value) {
+    return {
+        nodeName: '#text',
+        value,
+        parentNode: null,
+    };
+}
+const defaultTreeAdapter = {
+    //Node construction
+    createDocument() {
+        return {
+            nodeName: '#document',
+            mode: DOCUMENT_MODE.NO_QUIRKS,
+            childNodes: [],
+        };
+    },
+    createDocumentFragment() {
+        return {
+            nodeName: '#document-fragment',
+            childNodes: [],
+        };
+    },
+    createElement(tagName, namespaceURI, attrs) {
+        return {
+            nodeName: tagName,
+            tagName,
+            attrs,
+            namespaceURI,
+            childNodes: [],
+            parentNode: null,
+        };
+    },
+    createCommentNode(data) {
+        return {
+            nodeName: '#comment',
+            data,
+            parentNode: null,
+        };
+    },
+    //Tree mutation
+    appendChild(parentNode, newNode) {
+        parentNode.childNodes.push(newNode);
+        newNode.parentNode = parentNode;
+    },
+    insertBefore(parentNode, newNode, referenceNode) {
+        const insertionIdx = parentNode.childNodes.indexOf(referenceNode);
+        parentNode.childNodes.splice(insertionIdx, 0, newNode);
+        newNode.parentNode = parentNode;
+    },
+    setTemplateContent(templateElement, contentElement) {
+        templateElement.content = contentElement;
+    },
+    getTemplateContent(templateElement) {
+        return templateElement.content;
+    },
+    setDocumentType(document, name, publicId, systemId) {
+        const doctypeNode = document.childNodes.find((node) => node.nodeName === '#documentType');
+        if (doctypeNode) {
+            doctypeNode.name = name;
+            doctypeNode.publicId = publicId;
+            doctypeNode.systemId = systemId;
+        }
+        else {
+            const node = {
+                nodeName: '#documentType',
+                name,
+                publicId,
+                systemId,
+                parentNode: null,
+            };
+            defaultTreeAdapter.appendChild(document, node);
+        }
+    },
+    setDocumentMode(document, mode) {
+        document.mode = mode;
+    },
+    getDocumentMode(document) {
+        return document.mode;
+    },
+    detachNode(node) {
+        if (node.parentNode) {
+            const idx = node.parentNode.childNodes.indexOf(node);
+            node.parentNode.childNodes.splice(idx, 1);
+            node.parentNode = null;
+        }
+    },
+    insertText(parentNode, text) {
+        if (parentNode.childNodes.length > 0) {
+            const prevNode = parentNode.childNodes[parentNode.childNodes.length - 1];
+            if (defaultTreeAdapter.isTextNode(prevNode)) {
+                prevNode.value += text;
+                return;
+            }
+        }
+        defaultTreeAdapter.appendChild(parentNode, createTextNode(text));
+    },
+    insertTextBefore(parentNode, text, referenceNode) {
+        const prevNode = parentNode.childNodes[parentNode.childNodes.indexOf(referenceNode) - 1];
+        if (prevNode && defaultTreeAdapter.isTextNode(prevNode)) {
+            prevNode.value += text;
+        }
+        else {
+            defaultTreeAdapter.insertBefore(parentNode, createTextNode(text), referenceNode);
+        }
+    },
+    adoptAttributes(recipient, attrs) {
+        const recipientAttrsMap = new Set(recipient.attrs.map((attr) => attr.name));
+        for (let j = 0; j < attrs.length; j++) {
+            if (!recipientAttrsMap.has(attrs[j].name)) {
+                recipient.attrs.push(attrs[j]);
+            }
+        }
+    },
+    //Tree traversing
+    getFirstChild(node) {
+        return node.childNodes[0];
+    },
+    getChildNodes(node) {
+        return node.childNodes;
+    },
+    getParentNode(node) {
+        return node.parentNode;
+    },
+    getAttrList(element) {
+        return element.attrs;
+    },
+    //Node data
+    getTagName(element) {
+        return element.tagName;
+    },
+    getNamespaceURI(element) {
+        return element.namespaceURI;
+    },
+    getTextNodeContent(textNode) {
+        return textNode.value;
+    },
+    getCommentNodeContent(commentNode) {
+        return commentNode.data;
+    },
+    getDocumentTypeNodeName(doctypeNode) {
+        return doctypeNode.name;
+    },
+    getDocumentTypeNodePublicId(doctypeNode) {
+        return doctypeNode.publicId;
+    },
+    getDocumentTypeNodeSystemId(doctypeNode) {
+        return doctypeNode.systemId;
+    },
+    //Node types
+    isTextNode(node) {
+        return node.nodeName === '#text';
+    },
+    isCommentNode(node) {
+        return node.nodeName === '#comment';
+    },
+    isDocumentTypeNode(node) {
+        return node.nodeName === '#documentType';
+    },
+    isElementNode(node) {
+        return Object.prototype.hasOwnProperty.call(node, 'tagName');
+    },
+    // Source code location
+    setNodeSourceCodeLocation(node, location) {
+        node.sourceCodeLocation = location;
+    },
+    getNodeSourceCodeLocation(node) {
+        return node.sourceCodeLocation;
+    },
+    updateNodeSourceCodeLocation(node, endLocation) {
+        node.sourceCodeLocation = { ...node.sourceCodeLocation, ...endLocation };
+    },
+};
+//# sourceMappingURL=default.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/common/doctype.js
+
+//Const
+const VALID_DOCTYPE_NAME = 'html';
+const VALID_SYSTEM_ID = 'about:legacy-compat';
+const QUIRKS_MODE_SYSTEM_ID = 'http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd';
+const QUIRKS_MODE_PUBLIC_ID_PREFIXES = [
+    '+//silmaril//dtd html pro v0r11 19970101//',
+    '-//as//dtd html 3.0 aswedit + extensions//',
+    '-//advasoft ltd//dtd html 3.0 aswedit + extensions//',
+    '-//ietf//dtd html 2.0 level 1//',
+    '-//ietf//dtd html 2.0 level 2//',
+    '-//ietf//dtd html 2.0 strict level 1//',
+    '-//ietf//dtd html 2.0 strict level 2//',
+    '-//ietf//dtd html 2.0 strict//',
+    '-//ietf//dtd html 2.0//',
+    '-//ietf//dtd html 2.1e//',
+    '-//ietf//dtd html 3.0//',
+    '-//ietf//dtd html 3.2 final//',
+    '-//ietf//dtd html 3.2//',
+    '-//ietf//dtd html 3//',
+    '-//ietf//dtd html level 0//',
+    '-//ietf//dtd html level 1//',
+    '-//ietf//dtd html level 2//',
+    '-//ietf//dtd html level 3//',
+    '-//ietf//dtd html strict level 0//',
+    '-//ietf//dtd html strict level 1//',
+    '-//ietf//dtd html strict level 2//',
+    '-//ietf//dtd html strict level 3//',
+    '-//ietf//dtd html strict//',
+    '-//ietf//dtd html//',
+    '-//metrius//dtd metrius presentational//',
+    '-//microsoft//dtd internet explorer 2.0 html strict//',
+    '-//microsoft//dtd internet explorer 2.0 html//',
+    '-//microsoft//dtd internet explorer 2.0 tables//',
+    '-//microsoft//dtd internet explorer 3.0 html strict//',
+    '-//microsoft//dtd internet explorer 3.0 html//',
+    '-//microsoft//dtd internet explorer 3.0 tables//',
+    '-//netscape comm. corp.//dtd html//',
+    '-//netscape comm. corp.//dtd strict html//',
+    "-//o'reilly and associates//dtd html 2.0//",
+    "-//o'reilly and associates//dtd html extended 1.0//",
+    "-//o'reilly and associates//dtd html extended relaxed 1.0//",
+    '-//sq//dtd html 2.0 hotmetal + extensions//',
+    '-//softquad software//dtd hotmetal pro 6.0::19990601::extensions to html 4.0//',
+    '-//softquad//dtd hotmetal pro 4.0::19971010::extensions to html 4.0//',
+    '-//spyglass//dtd html 2.0 extended//',
+    '-//sun microsystems corp.//dtd hotjava html//',
+    '-//sun microsystems corp.//dtd hotjava strict html//',
+    '-//w3c//dtd html 3 1995-03-24//',
+    '-//w3c//dtd html 3.2 draft//',
+    '-//w3c//dtd html 3.2 final//',
+    '-//w3c//dtd html 3.2//',
+    '-//w3c//dtd html 3.2s draft//',
+    '-//w3c//dtd html 4.0 frameset//',
+    '-//w3c//dtd html 4.0 transitional//',
+    '-//w3c//dtd html experimental 19960712//',
+    '-//w3c//dtd html experimental 970421//',
+    '-//w3c//dtd w3 html//',
+    '-//w3o//dtd w3 html 3.0//',
+    '-//webtechs//dtd mozilla html 2.0//',
+    '-//webtechs//dtd mozilla html//',
+];
+const QUIRKS_MODE_NO_SYSTEM_ID_PUBLIC_ID_PREFIXES = [
+    ...QUIRKS_MODE_PUBLIC_ID_PREFIXES,
+    '-//w3c//dtd html 4.01 frameset//',
+    '-//w3c//dtd html 4.01 transitional//',
+];
+const QUIRKS_MODE_PUBLIC_IDS = new Set([
+    '-//w3o//dtd w3 html strict 3.0//en//',
+    '-/w3c/dtd html 4.0 transitional/en',
+    'html',
+]);
+const LIMITED_QUIRKS_PUBLIC_ID_PREFIXES = ['-//w3c//dtd xhtml 1.0 frameset//', '-//w3c//dtd xhtml 1.0 transitional//'];
+const LIMITED_QUIRKS_WITH_SYSTEM_ID_PUBLIC_ID_PREFIXES = [
+    ...LIMITED_QUIRKS_PUBLIC_ID_PREFIXES,
+    '-//w3c//dtd html 4.01 frameset//',
+    '-//w3c//dtd html 4.01 transitional//',
+];
+//Utils
+function hasPrefix(publicId, prefixes) {
+    return prefixes.some((prefix) => publicId.startsWith(prefix));
+}
+//API
+function isConforming(token) {
+    return (token.name === VALID_DOCTYPE_NAME &&
+        token.publicId === null &&
+        (token.systemId === null || token.systemId === VALID_SYSTEM_ID));
+}
+function getDocumentMode(token) {
+    if (token.name !== VALID_DOCTYPE_NAME) {
+        return DOCUMENT_MODE.QUIRKS;
+    }
+    const { systemId } = token;
+    if (systemId && systemId.toLowerCase() === QUIRKS_MODE_SYSTEM_ID) {
+        return DOCUMENT_MODE.QUIRKS;
+    }
+    let { publicId } = token;
+    if (publicId !== null) {
+        publicId = publicId.toLowerCase();
+        if (QUIRKS_MODE_PUBLIC_IDS.has(publicId)) {
+            return DOCUMENT_MODE.QUIRKS;
+        }
+        let prefixes = systemId === null ? QUIRKS_MODE_NO_SYSTEM_ID_PUBLIC_ID_PREFIXES : QUIRKS_MODE_PUBLIC_ID_PREFIXES;
+        if (hasPrefix(publicId, prefixes)) {
+            return DOCUMENT_MODE.QUIRKS;
+        }
+        prefixes =
+            systemId === null ? LIMITED_QUIRKS_PUBLIC_ID_PREFIXES : LIMITED_QUIRKS_WITH_SYSTEM_ID_PUBLIC_ID_PREFIXES;
+        if (hasPrefix(publicId, prefixes)) {
+            return DOCUMENT_MODE.LIMITED_QUIRKS;
+        }
+    }
+    return DOCUMENT_MODE.NO_QUIRKS;
+}
+//# sourceMappingURL=doctype.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/common/foreign-content.js
+
+//MIME types
+const MIME_TYPES = {
+    TEXT_HTML: 'text/html',
+    APPLICATION_XML: 'application/xhtml+xml',
+};
+//Attributes
+const DEFINITION_URL_ATTR = 'definitionurl';
+const ADJUSTED_DEFINITION_URL_ATTR = 'definitionURL';
+const SVG_ATTRS_ADJUSTMENT_MAP = new Map([
+    'attributeName',
+    'attributeType',
+    'baseFrequency',
+    'baseProfile',
+    'calcMode',
+    'clipPathUnits',
+    'diffuseConstant',
+    'edgeMode',
+    'filterUnits',
+    'glyphRef',
+    'gradientTransform',
+    'gradientUnits',
+    'kernelMatrix',
+    'kernelUnitLength',
+    'keyPoints',
+    'keySplines',
+    'keyTimes',
+    'lengthAdjust',
+    'limitingConeAngle',
+    'markerHeight',
+    'markerUnits',
+    'markerWidth',
+    'maskContentUnits',
+    'maskUnits',
+    'numOctaves',
+    'pathLength',
+    'patternContentUnits',
+    'patternTransform',
+    'patternUnits',
+    'pointsAtX',
+    'pointsAtY',
+    'pointsAtZ',
+    'preserveAlpha',
+    'preserveAspectRatio',
+    'primitiveUnits',
+    'refX',
+    'refY',
+    'repeatCount',
+    'repeatDur',
+    'requiredExtensions',
+    'requiredFeatures',
+    'specularConstant',
+    'specularExponent',
+    'spreadMethod',
+    'startOffset',
+    'stdDeviation',
+    'stitchTiles',
+    'surfaceScale',
+    'systemLanguage',
+    'tableValues',
+    'targetX',
+    'targetY',
+    'textLength',
+    'viewBox',
+    'viewTarget',
+    'xChannelSelector',
+    'yChannelSelector',
+    'zoomAndPan',
+].map((attr) => [attr.toLowerCase(), attr]));
+const XML_ATTRS_ADJUSTMENT_MAP = new Map([
+    ['xlink:actuate', { prefix: 'xlink', name: 'actuate', namespace: html_NS.XLINK }],
+    ['xlink:arcrole', { prefix: 'xlink', name: 'arcrole', namespace: html_NS.XLINK }],
+    ['xlink:href', { prefix: 'xlink', name: 'href', namespace: html_NS.XLINK }],
+    ['xlink:role', { prefix: 'xlink', name: 'role', namespace: html_NS.XLINK }],
+    ['xlink:show', { prefix: 'xlink', name: 'show', namespace: html_NS.XLINK }],
+    ['xlink:title', { prefix: 'xlink', name: 'title', namespace: html_NS.XLINK }],
+    ['xlink:type', { prefix: 'xlink', name: 'type', namespace: html_NS.XLINK }],
+    ['xml:base', { prefix: 'xml', name: 'base', namespace: html_NS.XML }],
+    ['xml:lang', { prefix: 'xml', name: 'lang', namespace: html_NS.XML }],
+    ['xml:space', { prefix: 'xml', name: 'space', namespace: html_NS.XML }],
+    ['xmlns', { prefix: '', name: 'xmlns', namespace: html_NS.XMLNS }],
+    ['xmlns:xlink', { prefix: 'xmlns', name: 'xlink', namespace: html_NS.XMLNS }],
+]);
+//SVG tag names adjustment map
+const SVG_TAG_NAMES_ADJUSTMENT_MAP = new Map([
+    'altGlyph',
+    'altGlyphDef',
+    'altGlyphItem',
+    'animateColor',
+    'animateMotion',
+    'animateTransform',
+    'clipPath',
+    'feBlend',
+    'feColorMatrix',
+    'feComponentTransfer',
+    'feComposite',
+    'feConvolveMatrix',
+    'feDiffuseLighting',
+    'feDisplacementMap',
+    'feDistantLight',
+    'feFlood',
+    'feFuncA',
+    'feFuncB',
+    'feFuncG',
+    'feFuncR',
+    'feGaussianBlur',
+    'feImage',
+    'feMerge',
+    'feMergeNode',
+    'feMorphology',
+    'feOffset',
+    'fePointLight',
+    'feSpecularLighting',
+    'feSpotLight',
+    'feTile',
+    'feTurbulence',
+    'foreignObject',
+    'glyphRef',
+    'linearGradient',
+    'radialGradient',
+    'textPath',
+].map((tn) => [tn.toLowerCase(), tn]));
+//Tags that causes exit from foreign content
+const EXITS_FOREIGN_CONTENT = new Set([
+    TAG_ID.B,
+    TAG_ID.BIG,
+    TAG_ID.BLOCKQUOTE,
+    TAG_ID.BODY,
+    TAG_ID.BR,
+    TAG_ID.CENTER,
+    TAG_ID.CODE,
+    TAG_ID.DD,
+    TAG_ID.DIV,
+    TAG_ID.DL,
+    TAG_ID.DT,
+    TAG_ID.EM,
+    TAG_ID.EMBED,
+    TAG_ID.H1,
+    TAG_ID.H2,
+    TAG_ID.H3,
+    TAG_ID.H4,
+    TAG_ID.H5,
+    TAG_ID.H6,
+    TAG_ID.HEAD,
+    TAG_ID.HR,
+    TAG_ID.I,
+    TAG_ID.IMG,
+    TAG_ID.LI,
+    TAG_ID.LISTING,
+    TAG_ID.MENU,
+    TAG_ID.META,
+    TAG_ID.NOBR,
+    TAG_ID.OL,
+    TAG_ID.P,
+    TAG_ID.PRE,
+    TAG_ID.RUBY,
+    TAG_ID.S,
+    TAG_ID.SMALL,
+    TAG_ID.SPAN,
+    TAG_ID.STRONG,
+    TAG_ID.STRIKE,
+    TAG_ID.SUB,
+    TAG_ID.SUP,
+    TAG_ID.TABLE,
+    TAG_ID.TT,
+    TAG_ID.U,
+    TAG_ID.UL,
+    TAG_ID.VAR,
+]);
+//Check exit from foreign content
+function causesExit(startTagToken) {
+    const tn = startTagToken.tagID;
+    const isFontWithAttrs = tn === TAG_ID.FONT &&
+        startTagToken.attrs.some(({ name }) => name === ATTRS.COLOR || name === ATTRS.SIZE || name === ATTRS.FACE);
+    return isFontWithAttrs || EXITS_FOREIGN_CONTENT.has(tn);
+}
+//Token adjustments
+function adjustTokenMathMLAttrs(token) {
+    for (let i = 0; i < token.attrs.length; i++) {
+        if (token.attrs[i].name === DEFINITION_URL_ATTR) {
+            token.attrs[i].name = ADJUSTED_DEFINITION_URL_ATTR;
+            break;
+        }
+    }
+}
+function adjustTokenSVGAttrs(token) {
+    for (let i = 0; i < token.attrs.length; i++) {
+        const adjustedAttrName = SVG_ATTRS_ADJUSTMENT_MAP.get(token.attrs[i].name);
+        if (adjustedAttrName != null) {
+            token.attrs[i].name = adjustedAttrName;
+        }
+    }
+}
+function adjustTokenXMLAttrs(token) {
+    for (let i = 0; i < token.attrs.length; i++) {
+        const adjustedAttrEntry = XML_ATTRS_ADJUSTMENT_MAP.get(token.attrs[i].name);
+        if (adjustedAttrEntry) {
+            token.attrs[i].prefix = adjustedAttrEntry.prefix;
+            token.attrs[i].name = adjustedAttrEntry.name;
+            token.attrs[i].namespace = adjustedAttrEntry.namespace;
+        }
+    }
+}
+function adjustTokenSVGTagName(token) {
+    const adjustedTagName = SVG_TAG_NAMES_ADJUSTMENT_MAP.get(token.tagName);
+    if (adjustedTagName != null) {
+        token.tagName = adjustedTagName;
+        token.tagID = getTagID(token.tagName);
+    }
+}
+//Integration points
+function isMathMLTextIntegrationPoint(tn, ns) {
+    return ns === html_NS.MATHML && (tn === TAG_ID.MI || tn === TAG_ID.MO || tn === TAG_ID.MN || tn === TAG_ID.MS || tn === TAG_ID.MTEXT);
+}
+function isHtmlIntegrationPoint(tn, ns, attrs) {
+    if (ns === html_NS.MATHML && tn === TAG_ID.ANNOTATION_XML) {
+        for (let i = 0; i < attrs.length; i++) {
+            if (attrs[i].name === ATTRS.ENCODING) {
+                const value = attrs[i].value.toLowerCase();
+                return value === MIME_TYPES.TEXT_HTML || value === MIME_TYPES.APPLICATION_XML;
+            }
+        }
+    }
+    return ns === html_NS.SVG && (tn === TAG_ID.FOREIGN_OBJECT || tn === TAG_ID.DESC || tn === TAG_ID.TITLE);
+}
+function isIntegrationPoint(tn, ns, attrs, foreignNS) {
+    return (((!foreignNS || foreignNS === html_NS.HTML) && isHtmlIntegrationPoint(tn, ns, attrs)) ||
+        ((!foreignNS || foreignNS === html_NS.MATHML) && isMathMLTextIntegrationPoint(tn, ns)));
+}
+//# sourceMappingURL=foreign-content.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/parser/index.js
+
+
+
+
+
+
+
+
+
+
+//Misc constants
+const HIDDEN_INPUT_TYPE = 'hidden';
+//Adoption agency loops iteration count
+const AA_OUTER_LOOP_ITER = 8;
+const AA_INNER_LOOP_ITER = 3;
+//Insertion modes
+var InsertionMode;
+(function (InsertionMode) {
+    InsertionMode[InsertionMode["INITIAL"] = 0] = "INITIAL";
+    InsertionMode[InsertionMode["BEFORE_HTML"] = 1] = "BEFORE_HTML";
+    InsertionMode[InsertionMode["BEFORE_HEAD"] = 2] = "BEFORE_HEAD";
+    InsertionMode[InsertionMode["IN_HEAD"] = 3] = "IN_HEAD";
+    InsertionMode[InsertionMode["IN_HEAD_NO_SCRIPT"] = 4] = "IN_HEAD_NO_SCRIPT";
+    InsertionMode[InsertionMode["AFTER_HEAD"] = 5] = "AFTER_HEAD";
+    InsertionMode[InsertionMode["IN_BODY"] = 6] = "IN_BODY";
+    InsertionMode[InsertionMode["TEXT"] = 7] = "TEXT";
+    InsertionMode[InsertionMode["IN_TABLE"] = 8] = "IN_TABLE";
+    InsertionMode[InsertionMode["IN_TABLE_TEXT"] = 9] = "IN_TABLE_TEXT";
+    InsertionMode[InsertionMode["IN_CAPTION"] = 10] = "IN_CAPTION";
+    InsertionMode[InsertionMode["IN_COLUMN_GROUP"] = 11] = "IN_COLUMN_GROUP";
+    InsertionMode[InsertionMode["IN_TABLE_BODY"] = 12] = "IN_TABLE_BODY";
+    InsertionMode[InsertionMode["IN_ROW"] = 13] = "IN_ROW";
+    InsertionMode[InsertionMode["IN_CELL"] = 14] = "IN_CELL";
+    InsertionMode[InsertionMode["IN_SELECT"] = 15] = "IN_SELECT";
+    InsertionMode[InsertionMode["IN_SELECT_IN_TABLE"] = 16] = "IN_SELECT_IN_TABLE";
+    InsertionMode[InsertionMode["IN_TEMPLATE"] = 17] = "IN_TEMPLATE";
+    InsertionMode[InsertionMode["AFTER_BODY"] = 18] = "AFTER_BODY";
+    InsertionMode[InsertionMode["IN_FRAMESET"] = 19] = "IN_FRAMESET";
+    InsertionMode[InsertionMode["AFTER_FRAMESET"] = 20] = "AFTER_FRAMESET";
+    InsertionMode[InsertionMode["AFTER_AFTER_BODY"] = 21] = "AFTER_AFTER_BODY";
+    InsertionMode[InsertionMode["AFTER_AFTER_FRAMESET"] = 22] = "AFTER_AFTER_FRAMESET";
+})(InsertionMode || (InsertionMode = {}));
+const BASE_LOC = {
+    startLine: -1,
+    startCol: -1,
+    startOffset: -1,
+    endLine: -1,
+    endCol: -1,
+    endOffset: -1,
+};
+const TABLE_STRUCTURE_TAGS = new Set([TAG_ID.TABLE, TAG_ID.TBODY, TAG_ID.TFOOT, TAG_ID.THEAD, TAG_ID.TR]);
+const defaultParserOptions = {
+    scriptingEnabled: true,
+    sourceCodeLocationInfo: false,
+    treeAdapter: defaultTreeAdapter,
+    onParseError: null,
+};
+//Parser
+class Parser {
+    constructor(options, document, fragmentContext = null, scriptHandler = null) {
+        this.fragmentContext = fragmentContext;
+        this.scriptHandler = scriptHandler;
+        this.currentToken = null;
+        this.stopped = false;
+        this.insertionMode = InsertionMode.INITIAL;
+        this.originalInsertionMode = InsertionMode.INITIAL;
+        this.headElement = null;
+        this.formElement = null;
+        /** Indicates that the current node is not an element in the HTML namespace */
+        this.currentNotInHTML = false;
+        /**
+         * The template insertion mode stack is maintained from the left.
+         * Ie. the topmost element will always have index 0.
+         */
+        this.tmplInsertionModeStack = [];
+        this.pendingCharacterTokens = [];
+        this.hasNonWhitespacePendingCharacterToken = false;
+        this.framesetOk = true;
+        this.skipNextNewLine = false;
+        this.fosterParentingEnabled = false;
+        this.options = {
+            ...defaultParserOptions,
+            ...options,
+        };
+        this.treeAdapter = this.options.treeAdapter;
+        this.onParseError = this.options.onParseError;
+        // Always enable location info if we report parse errors.
+        if (this.onParseError) {
+            this.options.sourceCodeLocationInfo = true;
+        }
+        this.document = document !== null && document !== void 0 ? document : this.treeAdapter.createDocument();
+        this.tokenizer = new Tokenizer(this.options, this);
+        this.activeFormattingElements = new FormattingElementList(this.treeAdapter);
+        this.fragmentContextID = fragmentContext ? getTagID(this.treeAdapter.getTagName(fragmentContext)) : TAG_ID.UNKNOWN;
+        this._setContextModes(fragmentContext !== null && fragmentContext !== void 0 ? fragmentContext : this.document, this.fragmentContextID);
+        this.openElements = new OpenElementStack(this.document, this.treeAdapter, this);
+    }
+    // API
+    static parse(html, options) {
+        const parser = new this(options);
+        parser.tokenizer.write(html, true);
+        return parser.document;
+    }
+    static getFragmentParser(fragmentContext, options) {
+        const opts = {
+            ...defaultParserOptions,
+            ...options,
+        };
+        //NOTE: use a <template> element as the fragment context if no context element was provided,
+        //so we will parse in a "forgiving" manner
+        fragmentContext !== null && fragmentContext !== void 0 ? fragmentContext : (fragmentContext = opts.treeAdapter.createElement(TAG_NAMES.TEMPLATE, html_NS.HTML, []));
+        //NOTE: create a fake element which will be used as the `document` for fragment parsing.
+        //This is important for jsdom, where a new `document` cannot be created. This led to
+        //fragment parsing messing with the main `document`.
+        const documentMock = opts.treeAdapter.createElement('documentmock', html_NS.HTML, []);
+        const parser = new this(opts, documentMock, fragmentContext);
+        if (parser.fragmentContextID === TAG_ID.TEMPLATE) {
+            parser.tmplInsertionModeStack.unshift(InsertionMode.IN_TEMPLATE);
+        }
+        parser._initTokenizerForFragmentParsing();
+        parser._insertFakeRootElement();
+        parser._resetInsertionMode();
+        parser._findFormInFragmentContext();
+        return parser;
+    }
+    getFragment() {
+        const rootElement = this.treeAdapter.getFirstChild(this.document);
+        const fragment = this.treeAdapter.createDocumentFragment();
+        this._adoptNodes(rootElement, fragment);
+        return fragment;
+    }
+    //Errors
+    _err(token, code, beforeToken) {
+        var _a;
+        if (!this.onParseError)
+            return;
+        const loc = (_a = token.location) !== null && _a !== void 0 ? _a : BASE_LOC;
+        const err = {
+            code,
+            startLine: loc.startLine,
+            startCol: loc.startCol,
+            startOffset: loc.startOffset,
+            endLine: beforeToken ? loc.startLine : loc.endLine,
+            endCol: beforeToken ? loc.startCol : loc.endCol,
+            endOffset: beforeToken ? loc.startOffset : loc.endOffset,
+        };
+        this.onParseError(err);
+    }
+    //Stack events
+    onItemPush(node, tid, isTop) {
+        var _a, _b;
+        (_b = (_a = this.treeAdapter).onItemPush) === null || _b === void 0 ? void 0 : _b.call(_a, node);
+        if (isTop && this.openElements.stackTop > 0)
+            this._setContextModes(node, tid);
+    }
+    onItemPop(node, isTop) {
+        var _a, _b;
+        if (this.options.sourceCodeLocationInfo) {
+            this._setEndLocation(node, this.currentToken);
+        }
+        (_b = (_a = this.treeAdapter).onItemPop) === null || _b === void 0 ? void 0 : _b.call(_a, node, this.openElements.current);
+        if (isTop) {
+            let current;
+            let currentTagId;
+            if (this.openElements.stackTop === 0 && this.fragmentContext) {
+                current = this.fragmentContext;
+                currentTagId = this.fragmentContextID;
+            }
+            else {
+                ({ current, currentTagId } = this.openElements);
+            }
+            this._setContextModes(current, currentTagId);
+        }
+    }
+    _setContextModes(current, tid) {
+        const isHTML = current === this.document || this.treeAdapter.getNamespaceURI(current) === html_NS.HTML;
+        this.currentNotInHTML = !isHTML;
+        this.tokenizer.inForeignNode = !isHTML && !this._isIntegrationPoint(tid, current);
+    }
+    _switchToTextParsing(currentToken, nextTokenizerState) {
+        this._insertElement(currentToken, html_NS.HTML);
+        this.tokenizer.state = nextTokenizerState;
+        this.originalInsertionMode = this.insertionMode;
+        this.insertionMode = InsertionMode.TEXT;
+    }
+    switchToPlaintextParsing() {
+        this.insertionMode = InsertionMode.TEXT;
+        this.originalInsertionMode = InsertionMode.IN_BODY;
+        this.tokenizer.state = TokenizerMode.PLAINTEXT;
+    }
+    //Fragment parsing
+    _getAdjustedCurrentElement() {
+        return this.openElements.stackTop === 0 && this.fragmentContext
+            ? this.fragmentContext
+            : this.openElements.current;
+    }
+    _findFormInFragmentContext() {
+        let node = this.fragmentContext;
+        while (node) {
+            if (this.treeAdapter.getTagName(node) === TAG_NAMES.FORM) {
+                this.formElement = node;
+                break;
+            }
+            node = this.treeAdapter.getParentNode(node);
+        }
+    }
+    _initTokenizerForFragmentParsing() {
+        if (!this.fragmentContext || this.treeAdapter.getNamespaceURI(this.fragmentContext) !== html_NS.HTML) {
+            return;
+        }
+        switch (this.fragmentContextID) {
+            case TAG_ID.TITLE:
+            case TAG_ID.TEXTAREA: {
+                this.tokenizer.state = TokenizerMode.RCDATA;
+                break;
+            }
+            case TAG_ID.STYLE:
+            case TAG_ID.XMP:
+            case TAG_ID.IFRAME:
+            case TAG_ID.NOEMBED:
+            case TAG_ID.NOFRAMES:
+            case TAG_ID.NOSCRIPT: {
+                this.tokenizer.state = TokenizerMode.RAWTEXT;
+                break;
+            }
+            case TAG_ID.SCRIPT: {
+                this.tokenizer.state = TokenizerMode.SCRIPT_DATA;
+                break;
+            }
+            case TAG_ID.PLAINTEXT: {
+                this.tokenizer.state = TokenizerMode.PLAINTEXT;
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    //Tree mutation
+    _setDocumentType(token) {
+        const name = token.name || '';
+        const publicId = token.publicId || '';
+        const systemId = token.systemId || '';
+        this.treeAdapter.setDocumentType(this.document, name, publicId, systemId);
+        if (token.location) {
+            const documentChildren = this.treeAdapter.getChildNodes(this.document);
+            const docTypeNode = documentChildren.find((node) => this.treeAdapter.isDocumentTypeNode(node));
+            if (docTypeNode) {
+                this.treeAdapter.setNodeSourceCodeLocation(docTypeNode, token.location);
+            }
+        }
+    }
+    _attachElementToTree(element, location) {
+        if (this.options.sourceCodeLocationInfo) {
+            const loc = location && {
+                ...location,
+                startTag: location,
+            };
+            this.treeAdapter.setNodeSourceCodeLocation(element, loc);
+        }
+        if (this._shouldFosterParentOnInsertion()) {
+            this._fosterParentElement(element);
+        }
+        else {
+            const parent = this.openElements.currentTmplContentOrNode;
+            this.treeAdapter.appendChild(parent, element);
+        }
+    }
+    _appendElement(token, namespaceURI) {
+        const element = this.treeAdapter.createElement(token.tagName, namespaceURI, token.attrs);
+        this._attachElementToTree(element, token.location);
+    }
+    _insertElement(token, namespaceURI) {
+        const element = this.treeAdapter.createElement(token.tagName, namespaceURI, token.attrs);
+        this._attachElementToTree(element, token.location);
+        this.openElements.push(element, token.tagID);
+    }
+    _insertFakeElement(tagName, tagID) {
+        const element = this.treeAdapter.createElement(tagName, html_NS.HTML, []);
+        this._attachElementToTree(element, null);
+        this.openElements.push(element, tagID);
+    }
+    _insertTemplate(token) {
+        const tmpl = this.treeAdapter.createElement(token.tagName, html_NS.HTML, token.attrs);
+        const content = this.treeAdapter.createDocumentFragment();
+        this.treeAdapter.setTemplateContent(tmpl, content);
+        this._attachElementToTree(tmpl, token.location);
+        this.openElements.push(tmpl, token.tagID);
+        if (this.options.sourceCodeLocationInfo)
+            this.treeAdapter.setNodeSourceCodeLocation(content, null);
+    }
+    _insertFakeRootElement() {
+        const element = this.treeAdapter.createElement(TAG_NAMES.HTML, html_NS.HTML, []);
+        if (this.options.sourceCodeLocationInfo)
+            this.treeAdapter.setNodeSourceCodeLocation(element, null);
+        this.treeAdapter.appendChild(this.openElements.current, element);
+        this.openElements.push(element, TAG_ID.HTML);
+    }
+    _appendCommentNode(token, parent) {
+        const commentNode = this.treeAdapter.createCommentNode(token.data);
+        this.treeAdapter.appendChild(parent, commentNode);
+        if (this.options.sourceCodeLocationInfo) {
+            this.treeAdapter.setNodeSourceCodeLocation(commentNode, token.location);
+        }
+    }
+    _insertCharacters(token) {
+        let parent;
+        let beforeElement;
+        if (this._shouldFosterParentOnInsertion()) {
+            ({ parent, beforeElement } = this._findFosterParentingLocation());
+            if (beforeElement) {
+                this.treeAdapter.insertTextBefore(parent, token.chars, beforeElement);
+            }
+            else {
+                this.treeAdapter.insertText(parent, token.chars);
+            }
+        }
+        else {
+            parent = this.openElements.currentTmplContentOrNode;
+            this.treeAdapter.insertText(parent, token.chars);
+        }
+        if (!token.location)
+            return;
+        const siblings = this.treeAdapter.getChildNodes(parent);
+        const textNodeIdx = beforeElement ? siblings.lastIndexOf(beforeElement) : siblings.length;
+        const textNode = siblings[textNodeIdx - 1];
+        //NOTE: if we have a location assigned by another token, then just update the end position
+        const tnLoc = this.treeAdapter.getNodeSourceCodeLocation(textNode);
+        if (tnLoc) {
+            const { endLine, endCol, endOffset } = token.location;
+            this.treeAdapter.updateNodeSourceCodeLocation(textNode, { endLine, endCol, endOffset });
+        }
+        else if (this.options.sourceCodeLocationInfo) {
+            this.treeAdapter.setNodeSourceCodeLocation(textNode, token.location);
+        }
+    }
+    _adoptNodes(donor, recipient) {
+        for (let child = this.treeAdapter.getFirstChild(donor); child; child = this.treeAdapter.getFirstChild(donor)) {
+            this.treeAdapter.detachNode(child);
+            this.treeAdapter.appendChild(recipient, child);
+        }
+    }
+    _setEndLocation(element, closingToken) {
+        if (this.treeAdapter.getNodeSourceCodeLocation(element) && closingToken.location) {
+            const ctLoc = closingToken.location;
+            const tn = this.treeAdapter.getTagName(element);
+            const endLoc = 
+            // NOTE: For cases like <p> <p> </p> - First 'p' closes without a closing
+            // tag and for cases like <td> <p> </td> - 'p' closes without a closing tag.
+            closingToken.type === TokenType.END_TAG && tn === closingToken.tagName
+                ? {
+                    endTag: { ...ctLoc },
+                    endLine: ctLoc.endLine,
+                    endCol: ctLoc.endCol,
+                    endOffset: ctLoc.endOffset,
+                }
+                : {
+                    endLine: ctLoc.startLine,
+                    endCol: ctLoc.startCol,
+                    endOffset: ctLoc.startOffset,
+                };
+            this.treeAdapter.updateNodeSourceCodeLocation(element, endLoc);
+        }
+    }
+    //Token processing
+    shouldProcessStartTagTokenInForeignContent(token) {
+        // Check that neither current === document, or ns === NS.HTML
+        if (!this.currentNotInHTML)
+            return false;
+        let current;
+        let currentTagId;
+        if (this.openElements.stackTop === 0 && this.fragmentContext) {
+            current = this.fragmentContext;
+            currentTagId = this.fragmentContextID;
+        }
+        else {
+            ({ current, currentTagId } = this.openElements);
+        }
+        if (token.tagID === TAG_ID.SVG &&
+            this.treeAdapter.getTagName(current) === TAG_NAMES.ANNOTATION_XML &&
+            this.treeAdapter.getNamespaceURI(current) === html_NS.MATHML) {
+            return false;
+        }
+        return (
+        // Check that `current` is not an integration point for HTML or MathML elements.
+        this.tokenizer.inForeignNode ||
+            // If it _is_ an integration point, then we might have to check that it is not an HTML
+            // integration point.
+            ((token.tagID === TAG_ID.MGLYPH || token.tagID === TAG_ID.MALIGNMARK) &&
+                !this._isIntegrationPoint(currentTagId, current, html_NS.HTML)));
+    }
+    _processToken(token) {
+        switch (token.type) {
+            case TokenType.CHARACTER: {
+                this.onCharacter(token);
+                break;
+            }
+            case TokenType.NULL_CHARACTER: {
+                this.onNullCharacter(token);
+                break;
+            }
+            case TokenType.COMMENT: {
+                this.onComment(token);
+                break;
+            }
+            case TokenType.DOCTYPE: {
+                this.onDoctype(token);
+                break;
+            }
+            case TokenType.START_TAG: {
+                this._processStartTag(token);
+                break;
+            }
+            case TokenType.END_TAG: {
+                this.onEndTag(token);
+                break;
+            }
+            case TokenType.EOF: {
+                this.onEof(token);
+                break;
+            }
+            case TokenType.WHITESPACE_CHARACTER: {
+                this.onWhitespaceCharacter(token);
+                break;
+            }
+        }
+    }
+    //Integration points
+    _isIntegrationPoint(tid, element, foreignNS) {
+        const ns = this.treeAdapter.getNamespaceURI(element);
+        const attrs = this.treeAdapter.getAttrList(element);
+        return isIntegrationPoint(tid, ns, attrs, foreignNS);
+    }
+    //Active formatting elements reconstruction
+    _reconstructActiveFormattingElements() {
+        const listLength = this.activeFormattingElements.entries.length;
+        if (listLength) {
+            const endIndex = this.activeFormattingElements.entries.findIndex((entry) => entry.type === EntryType.Marker || this.openElements.contains(entry.element));
+            const unopenIdx = endIndex < 0 ? listLength - 1 : endIndex - 1;
+            for (let i = unopenIdx; i >= 0; i--) {
+                const entry = this.activeFormattingElements.entries[i];
+                this._insertElement(entry.token, this.treeAdapter.getNamespaceURI(entry.element));
+                entry.element = this.openElements.current;
+            }
+        }
+    }
+    //Close elements
+    _closeTableCell() {
+        this.openElements.generateImpliedEndTags();
+        this.openElements.popUntilTableCellPopped();
+        this.activeFormattingElements.clearToLastMarker();
+        this.insertionMode = InsertionMode.IN_ROW;
+    }
+    _closePElement() {
+        this.openElements.generateImpliedEndTagsWithExclusion(TAG_ID.P);
+        this.openElements.popUntilTagNamePopped(TAG_ID.P);
+    }
+    //Insertion modes
+    _resetInsertionMode() {
+        for (let i = this.openElements.stackTop; i >= 0; i--) {
+            //Insertion mode reset map
+            switch (i === 0 && this.fragmentContext ? this.fragmentContextID : this.openElements.tagIDs[i]) {
+                case TAG_ID.TR: {
+                    this.insertionMode = InsertionMode.IN_ROW;
+                    return;
+                }
+                case TAG_ID.TBODY:
+                case TAG_ID.THEAD:
+                case TAG_ID.TFOOT: {
+                    this.insertionMode = InsertionMode.IN_TABLE_BODY;
+                    return;
+                }
+                case TAG_ID.CAPTION: {
+                    this.insertionMode = InsertionMode.IN_CAPTION;
+                    return;
+                }
+                case TAG_ID.COLGROUP: {
+                    this.insertionMode = InsertionMode.IN_COLUMN_GROUP;
+                    return;
+                }
+                case TAG_ID.TABLE: {
+                    this.insertionMode = InsertionMode.IN_TABLE;
+                    return;
+                }
+                case TAG_ID.BODY: {
+                    this.insertionMode = InsertionMode.IN_BODY;
+                    return;
+                }
+                case TAG_ID.FRAMESET: {
+                    this.insertionMode = InsertionMode.IN_FRAMESET;
+                    return;
+                }
+                case TAG_ID.SELECT: {
+                    this._resetInsertionModeForSelect(i);
+                    return;
+                }
+                case TAG_ID.TEMPLATE: {
+                    this.insertionMode = this.tmplInsertionModeStack[0];
+                    return;
+                }
+                case TAG_ID.HTML: {
+                    this.insertionMode = this.headElement ? InsertionMode.AFTER_HEAD : InsertionMode.BEFORE_HEAD;
+                    return;
+                }
+                case TAG_ID.TD:
+                case TAG_ID.TH: {
+                    if (i > 0) {
+                        this.insertionMode = InsertionMode.IN_CELL;
+                        return;
+                    }
+                    break;
+                }
+                case TAG_ID.HEAD: {
+                    if (i > 0) {
+                        this.insertionMode = InsertionMode.IN_HEAD;
+                        return;
+                    }
+                    break;
+                }
+            }
+        }
+        this.insertionMode = InsertionMode.IN_BODY;
+    }
+    _resetInsertionModeForSelect(selectIdx) {
+        if (selectIdx > 0) {
+            for (let i = selectIdx - 1; i > 0; i--) {
+                const tn = this.openElements.tagIDs[i];
+                if (tn === TAG_ID.TEMPLATE) {
+                    break;
+                }
+                else if (tn === TAG_ID.TABLE) {
+                    this.insertionMode = InsertionMode.IN_SELECT_IN_TABLE;
+                    return;
+                }
+            }
+        }
+        this.insertionMode = InsertionMode.IN_SELECT;
+    }
+    //Foster parenting
+    _isElementCausesFosterParenting(tn) {
+        return TABLE_STRUCTURE_TAGS.has(tn);
+    }
+    _shouldFosterParentOnInsertion() {
+        return this.fosterParentingEnabled && this._isElementCausesFosterParenting(this.openElements.currentTagId);
+    }
+    _findFosterParentingLocation() {
+        for (let i = this.openElements.stackTop; i >= 0; i--) {
+            const openElement = this.openElements.items[i];
+            switch (this.openElements.tagIDs[i]) {
+                case TAG_ID.TEMPLATE: {
+                    if (this.treeAdapter.getNamespaceURI(openElement) === html_NS.HTML) {
+                        return { parent: this.treeAdapter.getTemplateContent(openElement), beforeElement: null };
+                    }
+                    break;
+                }
+                case TAG_ID.TABLE: {
+                    const parent = this.treeAdapter.getParentNode(openElement);
+                    if (parent) {
+                        return { parent, beforeElement: openElement };
+                    }
+                    return { parent: this.openElements.items[i - 1], beforeElement: null };
+                }
+                default:
+                // Do nothing
+            }
+        }
+        return { parent: this.openElements.items[0], beforeElement: null };
+    }
+    _fosterParentElement(element) {
+        const location = this._findFosterParentingLocation();
+        if (location.beforeElement) {
+            this.treeAdapter.insertBefore(location.parent, element, location.beforeElement);
+        }
+        else {
+            this.treeAdapter.appendChild(location.parent, element);
+        }
+    }
+    //Special elements
+    _isSpecialElement(element, id) {
+        const ns = this.treeAdapter.getNamespaceURI(element);
+        return SPECIAL_ELEMENTS[ns].has(id);
+    }
+    onCharacter(token) {
+        this.skipNextNewLine = false;
+        if (this.tokenizer.inForeignNode) {
+            characterInForeignContent(this, token);
+            return;
+        }
+        switch (this.insertionMode) {
+            case InsertionMode.INITIAL: {
+                tokenInInitialMode(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HTML: {
+                tokenBeforeHtml(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HEAD: {
+                tokenBeforeHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD: {
+                tokenInHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD_NO_SCRIPT: {
+                tokenInHeadNoScript(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_HEAD: {
+                tokenAfterHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_BODY:
+            case InsertionMode.IN_CAPTION:
+            case InsertionMode.IN_CELL:
+            case InsertionMode.IN_TEMPLATE: {
+                characterInBody(this, token);
+                break;
+            }
+            case InsertionMode.TEXT:
+            case InsertionMode.IN_SELECT:
+            case InsertionMode.IN_SELECT_IN_TABLE: {
+                this._insertCharacters(token);
+                break;
+            }
+            case InsertionMode.IN_TABLE:
+            case InsertionMode.IN_TABLE_BODY:
+            case InsertionMode.IN_ROW: {
+                characterInTable(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_TEXT: {
+                characterInTableText(this, token);
+                break;
+            }
+            case InsertionMode.IN_COLUMN_GROUP: {
+                tokenInColumnGroup(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_BODY: {
+                tokenAfterBody(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_AFTER_BODY: {
+                tokenAfterAfterBody(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    onNullCharacter(token) {
+        this.skipNextNewLine = false;
+        if (this.tokenizer.inForeignNode) {
+            nullCharacterInForeignContent(this, token);
+            return;
+        }
+        switch (this.insertionMode) {
+            case InsertionMode.INITIAL: {
+                tokenInInitialMode(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HTML: {
+                tokenBeforeHtml(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HEAD: {
+                tokenBeforeHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD: {
+                tokenInHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD_NO_SCRIPT: {
+                tokenInHeadNoScript(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_HEAD: {
+                tokenAfterHead(this, token);
+                break;
+            }
+            case InsertionMode.TEXT: {
+                this._insertCharacters(token);
+                break;
+            }
+            case InsertionMode.IN_TABLE:
+            case InsertionMode.IN_TABLE_BODY:
+            case InsertionMode.IN_ROW: {
+                characterInTable(this, token);
+                break;
+            }
+            case InsertionMode.IN_COLUMN_GROUP: {
+                tokenInColumnGroup(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_BODY: {
+                tokenAfterBody(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_AFTER_BODY: {
+                tokenAfterAfterBody(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    onComment(token) {
+        this.skipNextNewLine = false;
+        if (this.currentNotInHTML) {
+            appendComment(this, token);
+            return;
+        }
+        switch (this.insertionMode) {
+            case InsertionMode.INITIAL:
+            case InsertionMode.BEFORE_HTML:
+            case InsertionMode.BEFORE_HEAD:
+            case InsertionMode.IN_HEAD:
+            case InsertionMode.IN_HEAD_NO_SCRIPT:
+            case InsertionMode.AFTER_HEAD:
+            case InsertionMode.IN_BODY:
+            case InsertionMode.IN_TABLE:
+            case InsertionMode.IN_CAPTION:
+            case InsertionMode.IN_COLUMN_GROUP:
+            case InsertionMode.IN_TABLE_BODY:
+            case InsertionMode.IN_ROW:
+            case InsertionMode.IN_CELL:
+            case InsertionMode.IN_SELECT:
+            case InsertionMode.IN_SELECT_IN_TABLE:
+            case InsertionMode.IN_TEMPLATE:
+            case InsertionMode.IN_FRAMESET:
+            case InsertionMode.AFTER_FRAMESET: {
+                appendComment(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_TEXT: {
+                tokenInTableText(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_BODY: {
+                appendCommentToRootHtmlElement(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_AFTER_BODY:
+            case InsertionMode.AFTER_AFTER_FRAMESET: {
+                appendCommentToDocument(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    onDoctype(token) {
+        this.skipNextNewLine = false;
+        switch (this.insertionMode) {
+            case InsertionMode.INITIAL: {
+                doctypeInInitialMode(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HEAD:
+            case InsertionMode.IN_HEAD:
+            case InsertionMode.IN_HEAD_NO_SCRIPT:
+            case InsertionMode.AFTER_HEAD: {
+                this._err(token, ERR.misplacedDoctype);
+                break;
+            }
+            case InsertionMode.IN_TABLE_TEXT: {
+                tokenInTableText(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    onStartTag(token) {
+        this.skipNextNewLine = false;
+        this.currentToken = token;
+        this._processStartTag(token);
+        if (token.selfClosing && !token.ackSelfClosing) {
+            this._err(token, ERR.nonVoidHtmlElementStartTagWithTrailingSolidus);
+        }
+    }
+    /**
+     * Processes a given start tag.
+     *
+     * `onStartTag` checks if a self-closing tag was recognized. When a token
+     * is moved inbetween multiple insertion modes, this check for self-closing
+     * could lead to false positives. To avoid this, `_processStartTag` is used
+     * for nested calls.
+     *
+     * @param token The token to process.
+     */
+    _processStartTag(token) {
+        if (this.shouldProcessStartTagTokenInForeignContent(token)) {
+            startTagInForeignContent(this, token);
+        }
+        else {
+            this._startTagOutsideForeignContent(token);
+        }
+    }
+    _startTagOutsideForeignContent(token) {
+        switch (this.insertionMode) {
+            case InsertionMode.INITIAL: {
+                tokenInInitialMode(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HTML: {
+                startTagBeforeHtml(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HEAD: {
+                startTagBeforeHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD: {
+                startTagInHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD_NO_SCRIPT: {
+                startTagInHeadNoScript(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_HEAD: {
+                startTagAfterHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_BODY: {
+                startTagInBody(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE: {
+                startTagInTable(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_TEXT: {
+                tokenInTableText(this, token);
+                break;
+            }
+            case InsertionMode.IN_CAPTION: {
+                startTagInCaption(this, token);
+                break;
+            }
+            case InsertionMode.IN_COLUMN_GROUP: {
+                startTagInColumnGroup(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_BODY: {
+                startTagInTableBody(this, token);
+                break;
+            }
+            case InsertionMode.IN_ROW: {
+                startTagInRow(this, token);
+                break;
+            }
+            case InsertionMode.IN_CELL: {
+                startTagInCell(this, token);
+                break;
+            }
+            case InsertionMode.IN_SELECT: {
+                startTagInSelect(this, token);
+                break;
+            }
+            case InsertionMode.IN_SELECT_IN_TABLE: {
+                startTagInSelectInTable(this, token);
+                break;
+            }
+            case InsertionMode.IN_TEMPLATE: {
+                startTagInTemplate(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_BODY: {
+                startTagAfterBody(this, token);
+                break;
+            }
+            case InsertionMode.IN_FRAMESET: {
+                startTagInFrameset(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_FRAMESET: {
+                startTagAfterFrameset(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_AFTER_BODY: {
+                startTagAfterAfterBody(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_AFTER_FRAMESET: {
+                startTagAfterAfterFrameset(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    onEndTag(token) {
+        this.skipNextNewLine = false;
+        this.currentToken = token;
+        if (this.currentNotInHTML) {
+            endTagInForeignContent(this, token);
+        }
+        else {
+            this._endTagOutsideForeignContent(token);
+        }
+    }
+    _endTagOutsideForeignContent(token) {
+        switch (this.insertionMode) {
+            case InsertionMode.INITIAL: {
+                tokenInInitialMode(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HTML: {
+                endTagBeforeHtml(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HEAD: {
+                endTagBeforeHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD: {
+                endTagInHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD_NO_SCRIPT: {
+                endTagInHeadNoScript(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_HEAD: {
+                endTagAfterHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_BODY: {
+                endTagInBody(this, token);
+                break;
+            }
+            case InsertionMode.TEXT: {
+                endTagInText(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE: {
+                endTagInTable(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_TEXT: {
+                tokenInTableText(this, token);
+                break;
+            }
+            case InsertionMode.IN_CAPTION: {
+                endTagInCaption(this, token);
+                break;
+            }
+            case InsertionMode.IN_COLUMN_GROUP: {
+                endTagInColumnGroup(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_BODY: {
+                endTagInTableBody(this, token);
+                break;
+            }
+            case InsertionMode.IN_ROW: {
+                endTagInRow(this, token);
+                break;
+            }
+            case InsertionMode.IN_CELL: {
+                endTagInCell(this, token);
+                break;
+            }
+            case InsertionMode.IN_SELECT: {
+                endTagInSelect(this, token);
+                break;
+            }
+            case InsertionMode.IN_SELECT_IN_TABLE: {
+                endTagInSelectInTable(this, token);
+                break;
+            }
+            case InsertionMode.IN_TEMPLATE: {
+                endTagInTemplate(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_BODY: {
+                endTagAfterBody(this, token);
+                break;
+            }
+            case InsertionMode.IN_FRAMESET: {
+                endTagInFrameset(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_FRAMESET: {
+                endTagAfterFrameset(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_AFTER_BODY: {
+                tokenAfterAfterBody(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    onEof(token) {
+        switch (this.insertionMode) {
+            case InsertionMode.INITIAL: {
+                tokenInInitialMode(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HTML: {
+                tokenBeforeHtml(this, token);
+                break;
+            }
+            case InsertionMode.BEFORE_HEAD: {
+                tokenBeforeHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD: {
+                tokenInHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_HEAD_NO_SCRIPT: {
+                tokenInHeadNoScript(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_HEAD: {
+                tokenAfterHead(this, token);
+                break;
+            }
+            case InsertionMode.IN_BODY:
+            case InsertionMode.IN_TABLE:
+            case InsertionMode.IN_CAPTION:
+            case InsertionMode.IN_COLUMN_GROUP:
+            case InsertionMode.IN_TABLE_BODY:
+            case InsertionMode.IN_ROW:
+            case InsertionMode.IN_CELL:
+            case InsertionMode.IN_SELECT:
+            case InsertionMode.IN_SELECT_IN_TABLE: {
+                eofInBody(this, token);
+                break;
+            }
+            case InsertionMode.TEXT: {
+                eofInText(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_TEXT: {
+                tokenInTableText(this, token);
+                break;
+            }
+            case InsertionMode.IN_TEMPLATE: {
+                eofInTemplate(this, token);
+                break;
+            }
+            case InsertionMode.AFTER_BODY:
+            case InsertionMode.IN_FRAMESET:
+            case InsertionMode.AFTER_FRAMESET:
+            case InsertionMode.AFTER_AFTER_BODY:
+            case InsertionMode.AFTER_AFTER_FRAMESET: {
+                stopParsing(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+    onWhitespaceCharacter(token) {
+        if (this.skipNextNewLine) {
+            this.skipNextNewLine = false;
+            if (token.chars.charCodeAt(0) === CODE_POINTS.LINE_FEED) {
+                if (token.chars.length === 1) {
+                    return;
+                }
+                token.chars = token.chars.substr(1);
+            }
+        }
+        if (this.tokenizer.inForeignNode) {
+            this._insertCharacters(token);
+            return;
+        }
+        switch (this.insertionMode) {
+            case InsertionMode.IN_HEAD:
+            case InsertionMode.IN_HEAD_NO_SCRIPT:
+            case InsertionMode.AFTER_HEAD:
+            case InsertionMode.TEXT:
+            case InsertionMode.IN_COLUMN_GROUP:
+            case InsertionMode.IN_SELECT:
+            case InsertionMode.IN_SELECT_IN_TABLE:
+            case InsertionMode.IN_FRAMESET:
+            case InsertionMode.AFTER_FRAMESET: {
+                this._insertCharacters(token);
+                break;
+            }
+            case InsertionMode.IN_BODY:
+            case InsertionMode.IN_CAPTION:
+            case InsertionMode.IN_CELL:
+            case InsertionMode.IN_TEMPLATE:
+            case InsertionMode.AFTER_BODY:
+            case InsertionMode.AFTER_AFTER_BODY:
+            case InsertionMode.AFTER_AFTER_FRAMESET: {
+                whitespaceCharacterInBody(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE:
+            case InsertionMode.IN_TABLE_BODY:
+            case InsertionMode.IN_ROW: {
+                characterInTable(this, token);
+                break;
+            }
+            case InsertionMode.IN_TABLE_TEXT: {
+                whitespaceCharacterInTableText(this, token);
+                break;
+            }
+            default:
+            // Do nothing
+        }
+    }
+}
+//Adoption agency algorithm
+//(see: http://www.whatwg.org/specs/web-apps/current-work/multipage/tree-construction.html#adoptionAgency)
+//------------------------------------------------------------------
+//Steps 5-8 of the algorithm
+function aaObtainFormattingElementEntry(p, token) {
+    let formattingElementEntry = p.activeFormattingElements.getElementEntryInScopeWithTagName(token.tagName);
+    if (formattingElementEntry) {
+        if (!p.openElements.contains(formattingElementEntry.element)) {
+            p.activeFormattingElements.removeEntry(formattingElementEntry);
+            formattingElementEntry = null;
+        }
+        else if (!p.openElements.hasInScope(token.tagID)) {
+            formattingElementEntry = null;
+        }
+    }
+    else {
+        genericEndTagInBody(p, token);
+    }
+    return formattingElementEntry;
+}
+//Steps 9 and 10 of the algorithm
+function aaObtainFurthestBlock(p, formattingElementEntry) {
+    let furthestBlock = null;
+    let idx = p.openElements.stackTop;
+    for (; idx >= 0; idx--) {
+        const element = p.openElements.items[idx];
+        if (element === formattingElementEntry.element) {
+            break;
+        }
+        if (p._isSpecialElement(element, p.openElements.tagIDs[idx])) {
+            furthestBlock = element;
+        }
+    }
+    if (!furthestBlock) {
+        p.openElements.shortenToLength(idx < 0 ? 0 : idx);
+        p.activeFormattingElements.removeEntry(formattingElementEntry);
+    }
+    return furthestBlock;
+}
+//Step 13 of the algorithm
+function aaInnerLoop(p, furthestBlock, formattingElement) {
+    let lastElement = furthestBlock;
+    let nextElement = p.openElements.getCommonAncestor(furthestBlock);
+    for (let i = 0, element = nextElement; element !== formattingElement; i++, element = nextElement) {
+        //NOTE: store the next element for the next loop iteration (it may be deleted from the stack by step 9.5)
+        nextElement = p.openElements.getCommonAncestor(element);
+        const elementEntry = p.activeFormattingElements.getElementEntry(element);
+        const counterOverflow = elementEntry && i >= AA_INNER_LOOP_ITER;
+        const shouldRemoveFromOpenElements = !elementEntry || counterOverflow;
+        if (shouldRemoveFromOpenElements) {
+            if (counterOverflow) {
+                p.activeFormattingElements.removeEntry(elementEntry);
+            }
+            p.openElements.remove(element);
+        }
+        else {
+            element = aaRecreateElementFromEntry(p, elementEntry);
+            if (lastElement === furthestBlock) {
+                p.activeFormattingElements.bookmark = elementEntry;
+            }
+            p.treeAdapter.detachNode(lastElement);
+            p.treeAdapter.appendChild(element, lastElement);
+            lastElement = element;
+        }
+    }
+    return lastElement;
+}
+//Step 13.7 of the algorithm
+function aaRecreateElementFromEntry(p, elementEntry) {
+    const ns = p.treeAdapter.getNamespaceURI(elementEntry.element);
+    const newElement = p.treeAdapter.createElement(elementEntry.token.tagName, ns, elementEntry.token.attrs);
+    p.openElements.replace(elementEntry.element, newElement);
+    elementEntry.element = newElement;
+    return newElement;
+}
+//Step 14 of the algorithm
+function aaInsertLastNodeInCommonAncestor(p, commonAncestor, lastElement) {
+    const tn = p.treeAdapter.getTagName(commonAncestor);
+    const tid = getTagID(tn);
+    if (p._isElementCausesFosterParenting(tid)) {
+        p._fosterParentElement(lastElement);
+    }
+    else {
+        const ns = p.treeAdapter.getNamespaceURI(commonAncestor);
+        if (tid === TAG_ID.TEMPLATE && ns === html_NS.HTML) {
+            commonAncestor = p.treeAdapter.getTemplateContent(commonAncestor);
+        }
+        p.treeAdapter.appendChild(commonAncestor, lastElement);
+    }
+}
+//Steps 15-19 of the algorithm
+function aaReplaceFormattingElement(p, furthestBlock, formattingElementEntry) {
+    const ns = p.treeAdapter.getNamespaceURI(formattingElementEntry.element);
+    const { token } = formattingElementEntry;
+    const newElement = p.treeAdapter.createElement(token.tagName, ns, token.attrs);
+    p._adoptNodes(furthestBlock, newElement);
+    p.treeAdapter.appendChild(furthestBlock, newElement);
+    p.activeFormattingElements.insertElementAfterBookmark(newElement, token);
+    p.activeFormattingElements.removeEntry(formattingElementEntry);
+    p.openElements.remove(formattingElementEntry.element);
+    p.openElements.insertAfter(furthestBlock, newElement, token.tagID);
+}
+//Algorithm entry point
+function callAdoptionAgency(p, token) {
+    for (let i = 0; i < AA_OUTER_LOOP_ITER; i++) {
+        const formattingElementEntry = aaObtainFormattingElementEntry(p, token);
+        if (!formattingElementEntry) {
+            break;
+        }
+        const furthestBlock = aaObtainFurthestBlock(p, formattingElementEntry);
+        if (!furthestBlock) {
+            break;
+        }
+        p.activeFormattingElements.bookmark = formattingElementEntry;
+        const lastElement = aaInnerLoop(p, furthestBlock, formattingElementEntry.element);
+        const commonAncestor = p.openElements.getCommonAncestor(formattingElementEntry.element);
+        p.treeAdapter.detachNode(lastElement);
+        if (commonAncestor)
+            aaInsertLastNodeInCommonAncestor(p, commonAncestor, lastElement);
+        aaReplaceFormattingElement(p, furthestBlock, formattingElementEntry);
+    }
+}
+//Generic token handlers
+//------------------------------------------------------------------
+function appendComment(p, token) {
+    p._appendCommentNode(token, p.openElements.currentTmplContentOrNode);
+}
+function appendCommentToRootHtmlElement(p, token) {
+    p._appendCommentNode(token, p.openElements.items[0]);
+}
+function appendCommentToDocument(p, token) {
+    p._appendCommentNode(token, p.document);
+}
+function stopParsing(p, token) {
+    p.stopped = true;
+    // NOTE: Set end locations for elements that remain on the open element stack.
+    if (token.location) {
+        // NOTE: If we are not in a fragment, `html` and `body` will stay on the stack.
+        // This is a problem, as we might overwrite their end position here.
+        const target = p.fragmentContext ? 0 : 2;
+        for (let i = p.openElements.stackTop; i >= target; i--) {
+            p._setEndLocation(p.openElements.items[i], token);
+        }
+        // Handle `html` and `body`
+        if (!p.fragmentContext && p.openElements.stackTop >= 0) {
+            const htmlElement = p.openElements.items[0];
+            const htmlLocation = p.treeAdapter.getNodeSourceCodeLocation(htmlElement);
+            if (htmlLocation && !htmlLocation.endTag) {
+                p._setEndLocation(htmlElement, token);
+                if (p.openElements.stackTop >= 1) {
+                    const bodyElement = p.openElements.items[1];
+                    const bodyLocation = p.treeAdapter.getNodeSourceCodeLocation(bodyElement);
+                    if (bodyLocation && !bodyLocation.endTag) {
+                        p._setEndLocation(bodyElement, token);
+                    }
+                }
+            }
+        }
+    }
+}
+// The "initial" insertion mode
+//------------------------------------------------------------------
+function doctypeInInitialMode(p, token) {
+    p._setDocumentType(token);
+    const mode = token.forceQuirks ? DOCUMENT_MODE.QUIRKS : getDocumentMode(token);
+    if (!isConforming(token)) {
+        p._err(token, ERR.nonConformingDoctype);
+    }
+    p.treeAdapter.setDocumentMode(p.document, mode);
+    p.insertionMode = InsertionMode.BEFORE_HTML;
+}
+function tokenInInitialMode(p, token) {
+    p._err(token, ERR.missingDoctype, true);
+    p.treeAdapter.setDocumentMode(p.document, DOCUMENT_MODE.QUIRKS);
+    p.insertionMode = InsertionMode.BEFORE_HTML;
+    p._processToken(token);
+}
+// The "before html" insertion mode
+//------------------------------------------------------------------
+function startTagBeforeHtml(p, token) {
+    if (token.tagID === TAG_ID.HTML) {
+        p._insertElement(token, html_NS.HTML);
+        p.insertionMode = InsertionMode.BEFORE_HEAD;
+    }
+    else {
+        tokenBeforeHtml(p, token);
+    }
+}
+function endTagBeforeHtml(p, token) {
+    const tn = token.tagID;
+    if (tn === TAG_ID.HTML || tn === TAG_ID.HEAD || tn === TAG_ID.BODY || tn === TAG_ID.BR) {
+        tokenBeforeHtml(p, token);
+    }
+}
+function tokenBeforeHtml(p, token) {
+    p._insertFakeRootElement();
+    p.insertionMode = InsertionMode.BEFORE_HEAD;
+    p._processToken(token);
+}
+// The "before head" insertion mode
+//------------------------------------------------------------------
+function startTagBeforeHead(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.HEAD: {
+            p._insertElement(token, html_NS.HTML);
+            p.headElement = p.openElements.current;
+            p.insertionMode = InsertionMode.IN_HEAD;
+            break;
+        }
+        default: {
+            tokenBeforeHead(p, token);
+        }
+    }
+}
+function endTagBeforeHead(p, token) {
+    const tn = token.tagID;
+    if (tn === TAG_ID.HEAD || tn === TAG_ID.BODY || tn === TAG_ID.HTML || tn === TAG_ID.BR) {
+        tokenBeforeHead(p, token);
+    }
+    else {
+        p._err(token, ERR.endTagWithoutMatchingOpenElement);
+    }
+}
+function tokenBeforeHead(p, token) {
+    p._insertFakeElement(TAG_NAMES.HEAD, TAG_ID.HEAD);
+    p.headElement = p.openElements.current;
+    p.insertionMode = InsertionMode.IN_HEAD;
+    p._processToken(token);
+}
+// The "in head" insertion mode
+//------------------------------------------------------------------
+function startTagInHead(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.BASE:
+        case TAG_ID.BASEFONT:
+        case TAG_ID.BGSOUND:
+        case TAG_ID.LINK:
+        case TAG_ID.META: {
+            p._appendElement(token, html_NS.HTML);
+            token.ackSelfClosing = true;
+            break;
+        }
+        case TAG_ID.TITLE: {
+            p._switchToTextParsing(token, TokenizerMode.RCDATA);
+            break;
+        }
+        case TAG_ID.NOSCRIPT: {
+            if (p.options.scriptingEnabled) {
+                p._switchToTextParsing(token, TokenizerMode.RAWTEXT);
+            }
+            else {
+                p._insertElement(token, html_NS.HTML);
+                p.insertionMode = InsertionMode.IN_HEAD_NO_SCRIPT;
+            }
+            break;
+        }
+        case TAG_ID.NOFRAMES:
+        case TAG_ID.STYLE: {
+            p._switchToTextParsing(token, TokenizerMode.RAWTEXT);
+            break;
+        }
+        case TAG_ID.SCRIPT: {
+            p._switchToTextParsing(token, TokenizerMode.SCRIPT_DATA);
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            p._insertTemplate(token);
+            p.activeFormattingElements.insertMarker();
+            p.framesetOk = false;
+            p.insertionMode = InsertionMode.IN_TEMPLATE;
+            p.tmplInsertionModeStack.unshift(InsertionMode.IN_TEMPLATE);
+            break;
+        }
+        case TAG_ID.HEAD: {
+            p._err(token, ERR.misplacedStartTagForHeadElement);
+            break;
+        }
+        default: {
+            tokenInHead(p, token);
+        }
+    }
+}
+function endTagInHead(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HEAD: {
+            p.openElements.pop();
+            p.insertionMode = InsertionMode.AFTER_HEAD;
+            break;
+        }
+        case TAG_ID.BODY:
+        case TAG_ID.BR:
+        case TAG_ID.HTML: {
+            tokenInHead(p, token);
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            templateEndTagInHead(p, token);
+            break;
+        }
+        default: {
+            p._err(token, ERR.endTagWithoutMatchingOpenElement);
+        }
+    }
+}
+function templateEndTagInHead(p, token) {
+    if (p.openElements.tmplCount > 0) {
+        p.openElements.generateImpliedEndTagsThoroughly();
+        if (p.openElements.currentTagId !== TAG_ID.TEMPLATE) {
+            p._err(token, ERR.closingOfElementWithOpenChildElements);
+        }
+        p.openElements.popUntilTagNamePopped(TAG_ID.TEMPLATE);
+        p.activeFormattingElements.clearToLastMarker();
+        p.tmplInsertionModeStack.shift();
+        p._resetInsertionMode();
+    }
+    else {
+        p._err(token, ERR.endTagWithoutMatchingOpenElement);
+    }
+}
+function tokenInHead(p, token) {
+    p.openElements.pop();
+    p.insertionMode = InsertionMode.AFTER_HEAD;
+    p._processToken(token);
+}
+// The "in head no script" insertion mode
+//------------------------------------------------------------------
+function startTagInHeadNoScript(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.BASEFONT:
+        case TAG_ID.BGSOUND:
+        case TAG_ID.HEAD:
+        case TAG_ID.LINK:
+        case TAG_ID.META:
+        case TAG_ID.NOFRAMES:
+        case TAG_ID.STYLE: {
+            startTagInHead(p, token);
+            break;
+        }
+        case TAG_ID.NOSCRIPT: {
+            p._err(token, ERR.nestedNoscriptInHead);
+            break;
+        }
+        default: {
+            tokenInHeadNoScript(p, token);
+        }
+    }
+}
+function endTagInHeadNoScript(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.NOSCRIPT: {
+            p.openElements.pop();
+            p.insertionMode = InsertionMode.IN_HEAD;
+            break;
+        }
+        case TAG_ID.BR: {
+            tokenInHeadNoScript(p, token);
+            break;
+        }
+        default: {
+            p._err(token, ERR.endTagWithoutMatchingOpenElement);
+        }
+    }
+}
+function tokenInHeadNoScript(p, token) {
+    const errCode = token.type === TokenType.EOF ? ERR.openElementsLeftAfterEof : ERR.disallowedContentInNoscriptInHead;
+    p._err(token, errCode);
+    p.openElements.pop();
+    p.insertionMode = InsertionMode.IN_HEAD;
+    p._processToken(token);
+}
+// The "after head" insertion mode
+//------------------------------------------------------------------
+function startTagAfterHead(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.BODY: {
+            p._insertElement(token, html_NS.HTML);
+            p.framesetOk = false;
+            p.insertionMode = InsertionMode.IN_BODY;
+            break;
+        }
+        case TAG_ID.FRAMESET: {
+            p._insertElement(token, html_NS.HTML);
+            p.insertionMode = InsertionMode.IN_FRAMESET;
+            break;
+        }
+        case TAG_ID.BASE:
+        case TAG_ID.BASEFONT:
+        case TAG_ID.BGSOUND:
+        case TAG_ID.LINK:
+        case TAG_ID.META:
+        case TAG_ID.NOFRAMES:
+        case TAG_ID.SCRIPT:
+        case TAG_ID.STYLE:
+        case TAG_ID.TEMPLATE:
+        case TAG_ID.TITLE: {
+            p._err(token, ERR.abandonedHeadElementChild);
+            p.openElements.push(p.headElement, TAG_ID.HEAD);
+            startTagInHead(p, token);
+            p.openElements.remove(p.headElement);
+            break;
+        }
+        case TAG_ID.HEAD: {
+            p._err(token, ERR.misplacedStartTagForHeadElement);
+            break;
+        }
+        default: {
+            tokenAfterHead(p, token);
+        }
+    }
+}
+function endTagAfterHead(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.BODY:
+        case TAG_ID.HTML:
+        case TAG_ID.BR: {
+            tokenAfterHead(p, token);
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            templateEndTagInHead(p, token);
+            break;
+        }
+        default: {
+            p._err(token, ERR.endTagWithoutMatchingOpenElement);
+        }
+    }
+}
+function tokenAfterHead(p, token) {
+    p._insertFakeElement(TAG_NAMES.BODY, TAG_ID.BODY);
+    p.insertionMode = InsertionMode.IN_BODY;
+    modeInBody(p, token);
+}
+// The "in body" insertion mode
+//------------------------------------------------------------------
+function modeInBody(p, token) {
+    switch (token.type) {
+        case TokenType.CHARACTER: {
+            characterInBody(p, token);
+            break;
+        }
+        case TokenType.WHITESPACE_CHARACTER: {
+            whitespaceCharacterInBody(p, token);
+            break;
+        }
+        case TokenType.COMMENT: {
+            appendComment(p, token);
+            break;
+        }
+        case TokenType.START_TAG: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TokenType.END_TAG: {
+            endTagInBody(p, token);
+            break;
+        }
+        case TokenType.EOF: {
+            eofInBody(p, token);
+            break;
+        }
+        default:
+        // Do nothing
+    }
+}
+function whitespaceCharacterInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._insertCharacters(token);
+}
+function characterInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._insertCharacters(token);
+    p.framesetOk = false;
+}
+function htmlStartTagInBody(p, token) {
+    if (p.openElements.tmplCount === 0) {
+        p.treeAdapter.adoptAttributes(p.openElements.items[0], token.attrs);
+    }
+}
+function bodyStartTagInBody(p, token) {
+    const bodyElement = p.openElements.tryPeekProperlyNestedBodyElement();
+    if (bodyElement && p.openElements.tmplCount === 0) {
+        p.framesetOk = false;
+        p.treeAdapter.adoptAttributes(bodyElement, token.attrs);
+    }
+}
+function framesetStartTagInBody(p, token) {
+    const bodyElement = p.openElements.tryPeekProperlyNestedBodyElement();
+    if (p.framesetOk && bodyElement) {
+        p.treeAdapter.detachNode(bodyElement);
+        p.openElements.popAllUpToHtmlElement();
+        p._insertElement(token, html_NS.HTML);
+        p.insertionMode = InsertionMode.IN_FRAMESET;
+    }
+}
+function addressStartTagInBody(p, token) {
+    if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    p._insertElement(token, html_NS.HTML);
+}
+function numberedHeaderStartTagInBody(p, token) {
+    if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    if (isNumberedHeader(p.openElements.currentTagId)) {
+        p.openElements.pop();
+    }
+    p._insertElement(token, html_NS.HTML);
+}
+function preStartTagInBody(p, token) {
+    if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    p._insertElement(token, html_NS.HTML);
+    //NOTE: If the next token is a U+000A LINE FEED (LF) character token, then ignore that token and move
+    //on to the next one. (Newlines at the start of pre blocks are ignored as an authoring convenience.)
+    p.skipNextNewLine = true;
+    p.framesetOk = false;
+}
+function formStartTagInBody(p, token) {
+    const inTemplate = p.openElements.tmplCount > 0;
+    if (!p.formElement || inTemplate) {
+        if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+            p._closePElement();
+        }
+        p._insertElement(token, html_NS.HTML);
+        if (!inTemplate) {
+            p.formElement = p.openElements.current;
+        }
+    }
+}
+function listItemStartTagInBody(p, token) {
+    p.framesetOk = false;
+    const tn = token.tagID;
+    for (let i = p.openElements.stackTop; i >= 0; i--) {
+        const elementId = p.openElements.tagIDs[i];
+        if ((tn === TAG_ID.LI && elementId === TAG_ID.LI) ||
+            ((tn === TAG_ID.DD || tn === TAG_ID.DT) && (elementId === TAG_ID.DD || elementId === TAG_ID.DT))) {
+            p.openElements.generateImpliedEndTagsWithExclusion(elementId);
+            p.openElements.popUntilTagNamePopped(elementId);
+            break;
+        }
+        if (elementId !== TAG_ID.ADDRESS &&
+            elementId !== TAG_ID.DIV &&
+            elementId !== TAG_ID.P &&
+            p._isSpecialElement(p.openElements.items[i], elementId)) {
+            break;
+        }
+    }
+    if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    p._insertElement(token, html_NS.HTML);
+}
+function plaintextStartTagInBody(p, token) {
+    if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    p._insertElement(token, html_NS.HTML);
+    p.tokenizer.state = TokenizerMode.PLAINTEXT;
+}
+function buttonStartTagInBody(p, token) {
+    if (p.openElements.hasInScope(TAG_ID.BUTTON)) {
+        p.openElements.generateImpliedEndTags();
+        p.openElements.popUntilTagNamePopped(TAG_ID.BUTTON);
+    }
+    p._reconstructActiveFormattingElements();
+    p._insertElement(token, html_NS.HTML);
+    p.framesetOk = false;
+}
+function aStartTagInBody(p, token) {
+    const activeElementEntry = p.activeFormattingElements.getElementEntryInScopeWithTagName(TAG_NAMES.A);
+    if (activeElementEntry) {
+        callAdoptionAgency(p, token);
+        p.openElements.remove(activeElementEntry.element);
+        p.activeFormattingElements.removeEntry(activeElementEntry);
+    }
+    p._reconstructActiveFormattingElements();
+    p._insertElement(token, html_NS.HTML);
+    p.activeFormattingElements.pushElement(p.openElements.current, token);
+}
+function bStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._insertElement(token, html_NS.HTML);
+    p.activeFormattingElements.pushElement(p.openElements.current, token);
+}
+function nobrStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    if (p.openElements.hasInScope(TAG_ID.NOBR)) {
+        callAdoptionAgency(p, token);
+        p._reconstructActiveFormattingElements();
+    }
+    p._insertElement(token, html_NS.HTML);
+    p.activeFormattingElements.pushElement(p.openElements.current, token);
+}
+function appletStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._insertElement(token, html_NS.HTML);
+    p.activeFormattingElements.insertMarker();
+    p.framesetOk = false;
+}
+function tableStartTagInBody(p, token) {
+    if (p.treeAdapter.getDocumentMode(p.document) !== DOCUMENT_MODE.QUIRKS && p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    p._insertElement(token, html_NS.HTML);
+    p.framesetOk = false;
+    p.insertionMode = InsertionMode.IN_TABLE;
+}
+function areaStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._appendElement(token, html_NS.HTML);
+    p.framesetOk = false;
+    token.ackSelfClosing = true;
+}
+function isHiddenInput(token) {
+    const inputType = getTokenAttr(token, ATTRS.TYPE);
+    return inputType != null && inputType.toLowerCase() === HIDDEN_INPUT_TYPE;
+}
+function inputStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._appendElement(token, html_NS.HTML);
+    if (!isHiddenInput(token)) {
+        p.framesetOk = false;
+    }
+    token.ackSelfClosing = true;
+}
+function paramStartTagInBody(p, token) {
+    p._appendElement(token, html_NS.HTML);
+    token.ackSelfClosing = true;
+}
+function hrStartTagInBody(p, token) {
+    if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    p._appendElement(token, html_NS.HTML);
+    p.framesetOk = false;
+    token.ackSelfClosing = true;
+}
+function imageStartTagInBody(p, token) {
+    token.tagName = TAG_NAMES.IMG;
+    token.tagID = TAG_ID.IMG;
+    areaStartTagInBody(p, token);
+}
+function textareaStartTagInBody(p, token) {
+    p._insertElement(token, html_NS.HTML);
+    //NOTE: If the next token is a U+000A LINE FEED (LF) character token, then ignore that token and move
+    //on to the next one. (Newlines at the start of textarea elements are ignored as an authoring convenience.)
+    p.skipNextNewLine = true;
+    p.tokenizer.state = TokenizerMode.RCDATA;
+    p.originalInsertionMode = p.insertionMode;
+    p.framesetOk = false;
+    p.insertionMode = InsertionMode.TEXT;
+}
+function xmpStartTagInBody(p, token) {
+    if (p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._closePElement();
+    }
+    p._reconstructActiveFormattingElements();
+    p.framesetOk = false;
+    p._switchToTextParsing(token, TokenizerMode.RAWTEXT);
+}
+function iframeStartTagInBody(p, token) {
+    p.framesetOk = false;
+    p._switchToTextParsing(token, TokenizerMode.RAWTEXT);
+}
+//NOTE: here we assume that we always act as an user agent with enabled plugins, so we parse
+//<noembed> as rawtext.
+function noembedStartTagInBody(p, token) {
+    p._switchToTextParsing(token, TokenizerMode.RAWTEXT);
+}
+function selectStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._insertElement(token, html_NS.HTML);
+    p.framesetOk = false;
+    p.insertionMode =
+        p.insertionMode === InsertionMode.IN_TABLE ||
+            p.insertionMode === InsertionMode.IN_CAPTION ||
+            p.insertionMode === InsertionMode.IN_TABLE_BODY ||
+            p.insertionMode === InsertionMode.IN_ROW ||
+            p.insertionMode === InsertionMode.IN_CELL
+            ? InsertionMode.IN_SELECT_IN_TABLE
+            : InsertionMode.IN_SELECT;
+}
+function optgroupStartTagInBody(p, token) {
+    if (p.openElements.currentTagId === TAG_ID.OPTION) {
+        p.openElements.pop();
+    }
+    p._reconstructActiveFormattingElements();
+    p._insertElement(token, html_NS.HTML);
+}
+function rbStartTagInBody(p, token) {
+    if (p.openElements.hasInScope(TAG_ID.RUBY)) {
+        p.openElements.generateImpliedEndTags();
+    }
+    p._insertElement(token, html_NS.HTML);
+}
+function rtStartTagInBody(p, token) {
+    if (p.openElements.hasInScope(TAG_ID.RUBY)) {
+        p.openElements.generateImpliedEndTagsWithExclusion(TAG_ID.RTC);
+    }
+    p._insertElement(token, html_NS.HTML);
+}
+function mathStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    adjustTokenMathMLAttrs(token);
+    adjustTokenXMLAttrs(token);
+    if (token.selfClosing) {
+        p._appendElement(token, html_NS.MATHML);
+    }
+    else {
+        p._insertElement(token, html_NS.MATHML);
+    }
+    token.ackSelfClosing = true;
+}
+function svgStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    adjustTokenSVGAttrs(token);
+    adjustTokenXMLAttrs(token);
+    if (token.selfClosing) {
+        p._appendElement(token, html_NS.SVG);
+    }
+    else {
+        p._insertElement(token, html_NS.SVG);
+    }
+    token.ackSelfClosing = true;
+}
+function genericStartTagInBody(p, token) {
+    p._reconstructActiveFormattingElements();
+    p._insertElement(token, html_NS.HTML);
+}
+function startTagInBody(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.I:
+        case TAG_ID.S:
+        case TAG_ID.B:
+        case TAG_ID.U:
+        case TAG_ID.EM:
+        case TAG_ID.TT:
+        case TAG_ID.BIG:
+        case TAG_ID.CODE:
+        case TAG_ID.FONT:
+        case TAG_ID.SMALL:
+        case TAG_ID.STRIKE:
+        case TAG_ID.STRONG: {
+            bStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.A: {
+            aStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.H1:
+        case TAG_ID.H2:
+        case TAG_ID.H3:
+        case TAG_ID.H4:
+        case TAG_ID.H5:
+        case TAG_ID.H6: {
+            numberedHeaderStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.P:
+        case TAG_ID.DL:
+        case TAG_ID.OL:
+        case TAG_ID.UL:
+        case TAG_ID.DIV:
+        case TAG_ID.DIR:
+        case TAG_ID.NAV:
+        case TAG_ID.MAIN:
+        case TAG_ID.MENU:
+        case TAG_ID.ASIDE:
+        case TAG_ID.CENTER:
+        case TAG_ID.FIGURE:
+        case TAG_ID.FOOTER:
+        case TAG_ID.HEADER:
+        case TAG_ID.HGROUP:
+        case TAG_ID.DIALOG:
+        case TAG_ID.DETAILS:
+        case TAG_ID.ADDRESS:
+        case TAG_ID.ARTICLE:
+        case TAG_ID.SECTION:
+        case TAG_ID.SUMMARY:
+        case TAG_ID.FIELDSET:
+        case TAG_ID.BLOCKQUOTE:
+        case TAG_ID.FIGCAPTION: {
+            addressStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.LI:
+        case TAG_ID.DD:
+        case TAG_ID.DT: {
+            listItemStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.BR:
+        case TAG_ID.IMG:
+        case TAG_ID.WBR:
+        case TAG_ID.AREA:
+        case TAG_ID.EMBED:
+        case TAG_ID.KEYGEN: {
+            areaStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.HR: {
+            hrStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.RB:
+        case TAG_ID.RTC: {
+            rbStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.RT:
+        case TAG_ID.RP: {
+            rtStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.PRE:
+        case TAG_ID.LISTING: {
+            preStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.XMP: {
+            xmpStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.SVG: {
+            svgStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.HTML: {
+            htmlStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.BASE:
+        case TAG_ID.LINK:
+        case TAG_ID.META:
+        case TAG_ID.STYLE:
+        case TAG_ID.TITLE:
+        case TAG_ID.SCRIPT:
+        case TAG_ID.BGSOUND:
+        case TAG_ID.BASEFONT:
+        case TAG_ID.TEMPLATE: {
+            startTagInHead(p, token);
+            break;
+        }
+        case TAG_ID.BODY: {
+            bodyStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.FORM: {
+            formStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.NOBR: {
+            nobrStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.MATH: {
+            mathStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.TABLE: {
+            tableStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.INPUT: {
+            inputStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.PARAM:
+        case TAG_ID.TRACK:
+        case TAG_ID.SOURCE: {
+            paramStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.IMAGE: {
+            imageStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.BUTTON: {
+            buttonStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.APPLET:
+        case TAG_ID.OBJECT:
+        case TAG_ID.MARQUEE: {
+            appletStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.IFRAME: {
+            iframeStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.SELECT: {
+            selectStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.OPTION:
+        case TAG_ID.OPTGROUP: {
+            optgroupStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.NOEMBED: {
+            noembedStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.FRAMESET: {
+            framesetStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.TEXTAREA: {
+            textareaStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.NOSCRIPT: {
+            if (p.options.scriptingEnabled) {
+                noembedStartTagInBody(p, token);
+            }
+            else {
+                genericStartTagInBody(p, token);
+            }
+            break;
+        }
+        case TAG_ID.PLAINTEXT: {
+            plaintextStartTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.COL:
+        case TAG_ID.TH:
+        case TAG_ID.TD:
+        case TAG_ID.TR:
+        case TAG_ID.HEAD:
+        case TAG_ID.FRAME:
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD:
+        case TAG_ID.CAPTION:
+        case TAG_ID.COLGROUP: {
+            // Ignore token
+            break;
+        }
+        default: {
+            genericStartTagInBody(p, token);
+        }
+    }
+}
+function bodyEndTagInBody(p, token) {
+    if (p.openElements.hasInScope(TAG_ID.BODY)) {
+        p.insertionMode = InsertionMode.AFTER_BODY;
+        //NOTE: <body> is never popped from the stack, so we need to updated
+        //the end location explicitly.
+        if (p.options.sourceCodeLocationInfo) {
+            const bodyElement = p.openElements.tryPeekProperlyNestedBodyElement();
+            if (bodyElement) {
+                p._setEndLocation(bodyElement, token);
+            }
+        }
+    }
+}
+function htmlEndTagInBody(p, token) {
+    if (p.openElements.hasInScope(TAG_ID.BODY)) {
+        p.insertionMode = InsertionMode.AFTER_BODY;
+        endTagAfterBody(p, token);
+    }
+}
+function addressEndTagInBody(p, token) {
+    const tn = token.tagID;
+    if (p.openElements.hasInScope(tn)) {
+        p.openElements.generateImpliedEndTags();
+        p.openElements.popUntilTagNamePopped(tn);
+    }
+}
+function formEndTagInBody(p) {
+    const inTemplate = p.openElements.tmplCount > 0;
+    const { formElement } = p;
+    if (!inTemplate) {
+        p.formElement = null;
+    }
+    if ((formElement || inTemplate) && p.openElements.hasInScope(TAG_ID.FORM)) {
+        p.openElements.generateImpliedEndTags();
+        if (inTemplate) {
+            p.openElements.popUntilTagNamePopped(TAG_ID.FORM);
+        }
+        else if (formElement) {
+            p.openElements.remove(formElement);
+        }
+    }
+}
+function pEndTagInBody(p) {
+    if (!p.openElements.hasInButtonScope(TAG_ID.P)) {
+        p._insertFakeElement(TAG_NAMES.P, TAG_ID.P);
+    }
+    p._closePElement();
+}
+function liEndTagInBody(p) {
+    if (p.openElements.hasInListItemScope(TAG_ID.LI)) {
+        p.openElements.generateImpliedEndTagsWithExclusion(TAG_ID.LI);
+        p.openElements.popUntilTagNamePopped(TAG_ID.LI);
+    }
+}
+function ddEndTagInBody(p, token) {
+    const tn = token.tagID;
+    if (p.openElements.hasInScope(tn)) {
+        p.openElements.generateImpliedEndTagsWithExclusion(tn);
+        p.openElements.popUntilTagNamePopped(tn);
+    }
+}
+function numberedHeaderEndTagInBody(p) {
+    if (p.openElements.hasNumberedHeaderInScope()) {
+        p.openElements.generateImpliedEndTags();
+        p.openElements.popUntilNumberedHeaderPopped();
+    }
+}
+function appletEndTagInBody(p, token) {
+    const tn = token.tagID;
+    if (p.openElements.hasInScope(tn)) {
+        p.openElements.generateImpliedEndTags();
+        p.openElements.popUntilTagNamePopped(tn);
+        p.activeFormattingElements.clearToLastMarker();
+    }
+}
+function brEndTagInBody(p) {
+    p._reconstructActiveFormattingElements();
+    p._insertFakeElement(TAG_NAMES.BR, TAG_ID.BR);
+    p.openElements.pop();
+    p.framesetOk = false;
+}
+function genericEndTagInBody(p, token) {
+    const tn = token.tagName;
+    const tid = token.tagID;
+    for (let i = p.openElements.stackTop; i > 0; i--) {
+        const element = p.openElements.items[i];
+        const elementId = p.openElements.tagIDs[i];
+        // Compare the tag name here, as the tag might not be a known tag with an ID.
+        if (tid === elementId && (tid !== TAG_ID.UNKNOWN || p.treeAdapter.getTagName(element) === tn)) {
+            p.openElements.generateImpliedEndTagsWithExclusion(tid);
+            if (p.openElements.stackTop >= i)
+                p.openElements.shortenToLength(i);
+            break;
+        }
+        if (p._isSpecialElement(element, elementId)) {
+            break;
+        }
+    }
+}
+function endTagInBody(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.A:
+        case TAG_ID.B:
+        case TAG_ID.I:
+        case TAG_ID.S:
+        case TAG_ID.U:
+        case TAG_ID.EM:
+        case TAG_ID.TT:
+        case TAG_ID.BIG:
+        case TAG_ID.CODE:
+        case TAG_ID.FONT:
+        case TAG_ID.NOBR:
+        case TAG_ID.SMALL:
+        case TAG_ID.STRIKE:
+        case TAG_ID.STRONG: {
+            callAdoptionAgency(p, token);
+            break;
+        }
+        case TAG_ID.P: {
+            pEndTagInBody(p);
+            break;
+        }
+        case TAG_ID.DL:
+        case TAG_ID.UL:
+        case TAG_ID.OL:
+        case TAG_ID.DIR:
+        case TAG_ID.DIV:
+        case TAG_ID.NAV:
+        case TAG_ID.PRE:
+        case TAG_ID.MAIN:
+        case TAG_ID.MENU:
+        case TAG_ID.ASIDE:
+        case TAG_ID.BUTTON:
+        case TAG_ID.CENTER:
+        case TAG_ID.FIGURE:
+        case TAG_ID.FOOTER:
+        case TAG_ID.HEADER:
+        case TAG_ID.HGROUP:
+        case TAG_ID.DIALOG:
+        case TAG_ID.ADDRESS:
+        case TAG_ID.ARTICLE:
+        case TAG_ID.DETAILS:
+        case TAG_ID.SECTION:
+        case TAG_ID.SUMMARY:
+        case TAG_ID.LISTING:
+        case TAG_ID.FIELDSET:
+        case TAG_ID.BLOCKQUOTE:
+        case TAG_ID.FIGCAPTION: {
+            addressEndTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.LI: {
+            liEndTagInBody(p);
+            break;
+        }
+        case TAG_ID.DD:
+        case TAG_ID.DT: {
+            ddEndTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.H1:
+        case TAG_ID.H2:
+        case TAG_ID.H3:
+        case TAG_ID.H4:
+        case TAG_ID.H5:
+        case TAG_ID.H6: {
+            numberedHeaderEndTagInBody(p);
+            break;
+        }
+        case TAG_ID.BR: {
+            brEndTagInBody(p);
+            break;
+        }
+        case TAG_ID.BODY: {
+            bodyEndTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.HTML: {
+            htmlEndTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.FORM: {
+            formEndTagInBody(p);
+            break;
+        }
+        case TAG_ID.APPLET:
+        case TAG_ID.OBJECT:
+        case TAG_ID.MARQUEE: {
+            appletEndTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            templateEndTagInHead(p, token);
+            break;
+        }
+        default: {
+            genericEndTagInBody(p, token);
+        }
+    }
+}
+function eofInBody(p, token) {
+    if (p.tmplInsertionModeStack.length > 0) {
+        eofInTemplate(p, token);
+    }
+    else {
+        stopParsing(p, token);
+    }
+}
+// The "text" insertion mode
+//------------------------------------------------------------------
+function endTagInText(p, token) {
+    var _a;
+    if (token.tagID === TAG_ID.SCRIPT) {
+        (_a = p.scriptHandler) === null || _a === void 0 ? void 0 : _a.call(p, p.openElements.current);
+    }
+    p.openElements.pop();
+    p.insertionMode = p.originalInsertionMode;
+}
+function eofInText(p, token) {
+    p._err(token, ERR.eofInElementThatCanContainOnlyText);
+    p.openElements.pop();
+    p.insertionMode = p.originalInsertionMode;
+    p.onEof(token);
+}
+// The "in table" insertion mode
+//------------------------------------------------------------------
+function characterInTable(p, token) {
+    if (TABLE_STRUCTURE_TAGS.has(p.openElements.currentTagId)) {
+        p.pendingCharacterTokens.length = 0;
+        p.hasNonWhitespacePendingCharacterToken = false;
+        p.originalInsertionMode = p.insertionMode;
+        p.insertionMode = InsertionMode.IN_TABLE_TEXT;
+        switch (token.type) {
+            case TokenType.CHARACTER: {
+                characterInTableText(p, token);
+                break;
+            }
+            case TokenType.WHITESPACE_CHARACTER: {
+                whitespaceCharacterInTableText(p, token);
+                break;
+            }
+            // Ignore null
+        }
+    }
+    else {
+        tokenInTable(p, token);
+    }
+}
+function captionStartTagInTable(p, token) {
+    p.openElements.clearBackToTableContext();
+    p.activeFormattingElements.insertMarker();
+    p._insertElement(token, html_NS.HTML);
+    p.insertionMode = InsertionMode.IN_CAPTION;
+}
+function colgroupStartTagInTable(p, token) {
+    p.openElements.clearBackToTableContext();
+    p._insertElement(token, html_NS.HTML);
+    p.insertionMode = InsertionMode.IN_COLUMN_GROUP;
+}
+function colStartTagInTable(p, token) {
+    p.openElements.clearBackToTableContext();
+    p._insertFakeElement(TAG_NAMES.COLGROUP, TAG_ID.COLGROUP);
+    p.insertionMode = InsertionMode.IN_COLUMN_GROUP;
+    startTagInColumnGroup(p, token);
+}
+function tbodyStartTagInTable(p, token) {
+    p.openElements.clearBackToTableContext();
+    p._insertElement(token, html_NS.HTML);
+    p.insertionMode = InsertionMode.IN_TABLE_BODY;
+}
+function tdStartTagInTable(p, token) {
+    p.openElements.clearBackToTableContext();
+    p._insertFakeElement(TAG_NAMES.TBODY, TAG_ID.TBODY);
+    p.insertionMode = InsertionMode.IN_TABLE_BODY;
+    startTagInTableBody(p, token);
+}
+function tableStartTagInTable(p, token) {
+    if (p.openElements.hasInTableScope(TAG_ID.TABLE)) {
+        p.openElements.popUntilTagNamePopped(TAG_ID.TABLE);
+        p._resetInsertionMode();
+        p._processStartTag(token);
+    }
+}
+function inputStartTagInTable(p, token) {
+    if (isHiddenInput(token)) {
+        p._appendElement(token, html_NS.HTML);
+    }
+    else {
+        tokenInTable(p, token);
+    }
+    token.ackSelfClosing = true;
+}
+function formStartTagInTable(p, token) {
+    if (!p.formElement && p.openElements.tmplCount === 0) {
+        p._insertElement(token, html_NS.HTML);
+        p.formElement = p.openElements.current;
+        p.openElements.pop();
+    }
+}
+function startTagInTable(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.TD:
+        case TAG_ID.TH:
+        case TAG_ID.TR: {
+            tdStartTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.STYLE:
+        case TAG_ID.SCRIPT:
+        case TAG_ID.TEMPLATE: {
+            startTagInHead(p, token);
+            break;
+        }
+        case TAG_ID.COL: {
+            colStartTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.FORM: {
+            formStartTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.TABLE: {
+            tableStartTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD: {
+            tbodyStartTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.INPUT: {
+            inputStartTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.CAPTION: {
+            captionStartTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.COLGROUP: {
+            colgroupStartTagInTable(p, token);
+            break;
+        }
+        default: {
+            tokenInTable(p, token);
+        }
+    }
+}
+function endTagInTable(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.TABLE: {
+            if (p.openElements.hasInTableScope(TAG_ID.TABLE)) {
+                p.openElements.popUntilTagNamePopped(TAG_ID.TABLE);
+                p._resetInsertionMode();
+            }
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            templateEndTagInHead(p, token);
+            break;
+        }
+        case TAG_ID.BODY:
+        case TAG_ID.CAPTION:
+        case TAG_ID.COL:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.HTML:
+        case TAG_ID.TBODY:
+        case TAG_ID.TD:
+        case TAG_ID.TFOOT:
+        case TAG_ID.TH:
+        case TAG_ID.THEAD:
+        case TAG_ID.TR: {
+            // Ignore token
+            break;
+        }
+        default: {
+            tokenInTable(p, token);
+        }
+    }
+}
+function tokenInTable(p, token) {
+    const savedFosterParentingState = p.fosterParentingEnabled;
+    p.fosterParentingEnabled = true;
+    // Process token in `In Body` mode
+    modeInBody(p, token);
+    p.fosterParentingEnabled = savedFosterParentingState;
+}
+// The "in table text" insertion mode
+//------------------------------------------------------------------
+function whitespaceCharacterInTableText(p, token) {
+    p.pendingCharacterTokens.push(token);
+}
+function characterInTableText(p, token) {
+    p.pendingCharacterTokens.push(token);
+    p.hasNonWhitespacePendingCharacterToken = true;
+}
+function tokenInTableText(p, token) {
+    let i = 0;
+    if (p.hasNonWhitespacePendingCharacterToken) {
+        for (; i < p.pendingCharacterTokens.length; i++) {
+            tokenInTable(p, p.pendingCharacterTokens[i]);
+        }
+    }
+    else {
+        for (; i < p.pendingCharacterTokens.length; i++) {
+            p._insertCharacters(p.pendingCharacterTokens[i]);
+        }
+    }
+    p.insertionMode = p.originalInsertionMode;
+    p._processToken(token);
+}
+// The "in caption" insertion mode
+//------------------------------------------------------------------
+const TABLE_VOID_ELEMENTS = new Set([TAG_ID.CAPTION, TAG_ID.COL, TAG_ID.COLGROUP, TAG_ID.TBODY, TAG_ID.TD, TAG_ID.TFOOT, TAG_ID.TH, TAG_ID.THEAD, TAG_ID.TR]);
+function startTagInCaption(p, token) {
+    const tn = token.tagID;
+    if (TABLE_VOID_ELEMENTS.has(tn)) {
+        if (p.openElements.hasInTableScope(TAG_ID.CAPTION)) {
+            p.openElements.generateImpliedEndTags();
+            p.openElements.popUntilTagNamePopped(TAG_ID.CAPTION);
+            p.activeFormattingElements.clearToLastMarker();
+            p.insertionMode = InsertionMode.IN_TABLE;
+            startTagInTable(p, token);
+        }
+    }
+    else {
+        startTagInBody(p, token);
+    }
+}
+function endTagInCaption(p, token) {
+    const tn = token.tagID;
+    switch (tn) {
+        case TAG_ID.CAPTION:
+        case TAG_ID.TABLE: {
+            if (p.openElements.hasInTableScope(TAG_ID.CAPTION)) {
+                p.openElements.generateImpliedEndTags();
+                p.openElements.popUntilTagNamePopped(TAG_ID.CAPTION);
+                p.activeFormattingElements.clearToLastMarker();
+                p.insertionMode = InsertionMode.IN_TABLE;
+                if (tn === TAG_ID.TABLE) {
+                    endTagInTable(p, token);
+                }
+            }
+            break;
+        }
+        case TAG_ID.BODY:
+        case TAG_ID.COL:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.HTML:
+        case TAG_ID.TBODY:
+        case TAG_ID.TD:
+        case TAG_ID.TFOOT:
+        case TAG_ID.TH:
+        case TAG_ID.THEAD:
+        case TAG_ID.TR: {
+            // Ignore token
+            break;
+        }
+        default: {
+            endTagInBody(p, token);
+        }
+    }
+}
+// The "in column group" insertion mode
+//------------------------------------------------------------------
+function startTagInColumnGroup(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.COL: {
+            p._appendElement(token, html_NS.HTML);
+            token.ackSelfClosing = true;
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            startTagInHead(p, token);
+            break;
+        }
+        default: {
+            tokenInColumnGroup(p, token);
+        }
+    }
+}
+function endTagInColumnGroup(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.COLGROUP: {
+            if (p.openElements.currentTagId === TAG_ID.COLGROUP) {
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE;
+            }
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            templateEndTagInHead(p, token);
+            break;
+        }
+        case TAG_ID.COL: {
+            // Ignore token
+            break;
+        }
+        default: {
+            tokenInColumnGroup(p, token);
+        }
+    }
+}
+function tokenInColumnGroup(p, token) {
+    if (p.openElements.currentTagId === TAG_ID.COLGROUP) {
+        p.openElements.pop();
+        p.insertionMode = InsertionMode.IN_TABLE;
+        p._processToken(token);
+    }
+}
+// The "in table body" insertion mode
+//------------------------------------------------------------------
+function startTagInTableBody(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.TR: {
+            p.openElements.clearBackToTableBodyContext();
+            p._insertElement(token, html_NS.HTML);
+            p.insertionMode = InsertionMode.IN_ROW;
+            break;
+        }
+        case TAG_ID.TH:
+        case TAG_ID.TD: {
+            p.openElements.clearBackToTableBodyContext();
+            p._insertFakeElement(TAG_NAMES.TR, TAG_ID.TR);
+            p.insertionMode = InsertionMode.IN_ROW;
+            startTagInRow(p, token);
+            break;
+        }
+        case TAG_ID.CAPTION:
+        case TAG_ID.COL:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD: {
+            if (p.openElements.hasTableBodyContextInTableScope()) {
+                p.openElements.clearBackToTableBodyContext();
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE;
+                startTagInTable(p, token);
+            }
+            break;
+        }
+        default: {
+            startTagInTable(p, token);
+        }
+    }
+}
+function endTagInTableBody(p, token) {
+    const tn = token.tagID;
+    switch (token.tagID) {
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD: {
+            if (p.openElements.hasInTableScope(tn)) {
+                p.openElements.clearBackToTableBodyContext();
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE;
+            }
+            break;
+        }
+        case TAG_ID.TABLE: {
+            if (p.openElements.hasTableBodyContextInTableScope()) {
+                p.openElements.clearBackToTableBodyContext();
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE;
+                endTagInTable(p, token);
+            }
+            break;
+        }
+        case TAG_ID.BODY:
+        case TAG_ID.CAPTION:
+        case TAG_ID.COL:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.HTML:
+        case TAG_ID.TD:
+        case TAG_ID.TH:
+        case TAG_ID.TR: {
+            // Ignore token
+            break;
+        }
+        default: {
+            endTagInTable(p, token);
+        }
+    }
+}
+// The "in row" insertion mode
+//------------------------------------------------------------------
+function startTagInRow(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.TH:
+        case TAG_ID.TD: {
+            p.openElements.clearBackToTableRowContext();
+            p._insertElement(token, html_NS.HTML);
+            p.insertionMode = InsertionMode.IN_CELL;
+            p.activeFormattingElements.insertMarker();
+            break;
+        }
+        case TAG_ID.CAPTION:
+        case TAG_ID.COL:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD:
+        case TAG_ID.TR: {
+            if (p.openElements.hasInTableScope(TAG_ID.TR)) {
+                p.openElements.clearBackToTableRowContext();
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE_BODY;
+                startTagInTableBody(p, token);
+            }
+            break;
+        }
+        default: {
+            startTagInTable(p, token);
+        }
+    }
+}
+function endTagInRow(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.TR: {
+            if (p.openElements.hasInTableScope(TAG_ID.TR)) {
+                p.openElements.clearBackToTableRowContext();
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE_BODY;
+            }
+            break;
+        }
+        case TAG_ID.TABLE: {
+            if (p.openElements.hasInTableScope(TAG_ID.TR)) {
+                p.openElements.clearBackToTableRowContext();
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE_BODY;
+                endTagInTableBody(p, token);
+            }
+            break;
+        }
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD: {
+            if (p.openElements.hasInTableScope(token.tagID) || p.openElements.hasInTableScope(TAG_ID.TR)) {
+                p.openElements.clearBackToTableRowContext();
+                p.openElements.pop();
+                p.insertionMode = InsertionMode.IN_TABLE_BODY;
+                endTagInTableBody(p, token);
+            }
+            break;
+        }
+        case TAG_ID.BODY:
+        case TAG_ID.CAPTION:
+        case TAG_ID.COL:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.HTML:
+        case TAG_ID.TD:
+        case TAG_ID.TH: {
+            // Ignore end tag
+            break;
+        }
+        default: {
+            endTagInTable(p, token);
+        }
+    }
+}
+// The "in cell" insertion mode
+//------------------------------------------------------------------
+function startTagInCell(p, token) {
+    const tn = token.tagID;
+    if (TABLE_VOID_ELEMENTS.has(tn)) {
+        if (p.openElements.hasInTableScope(TAG_ID.TD) || p.openElements.hasInTableScope(TAG_ID.TH)) {
+            p._closeTableCell();
+            startTagInRow(p, token);
+        }
+    }
+    else {
+        startTagInBody(p, token);
+    }
+}
+function endTagInCell(p, token) {
+    const tn = token.tagID;
+    switch (tn) {
+        case TAG_ID.TD:
+        case TAG_ID.TH: {
+            if (p.openElements.hasInTableScope(tn)) {
+                p.openElements.generateImpliedEndTags();
+                p.openElements.popUntilTagNamePopped(tn);
+                p.activeFormattingElements.clearToLastMarker();
+                p.insertionMode = InsertionMode.IN_ROW;
+            }
+            break;
+        }
+        case TAG_ID.TABLE:
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD:
+        case TAG_ID.TR: {
+            if (p.openElements.hasInTableScope(tn)) {
+                p._closeTableCell();
+                endTagInRow(p, token);
+            }
+            break;
+        }
+        case TAG_ID.BODY:
+        case TAG_ID.CAPTION:
+        case TAG_ID.COL:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.HTML: {
+            // Ignore token
+            break;
+        }
+        default: {
+            endTagInBody(p, token);
+        }
+    }
+}
+// The "in select" insertion mode
+//------------------------------------------------------------------
+function startTagInSelect(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.OPTION: {
+            if (p.openElements.currentTagId === TAG_ID.OPTION) {
+                p.openElements.pop();
+            }
+            p._insertElement(token, html_NS.HTML);
+            break;
+        }
+        case TAG_ID.OPTGROUP: {
+            if (p.openElements.currentTagId === TAG_ID.OPTION) {
+                p.openElements.pop();
+            }
+            if (p.openElements.currentTagId === TAG_ID.OPTGROUP) {
+                p.openElements.pop();
+            }
+            p._insertElement(token, html_NS.HTML);
+            break;
+        }
+        case TAG_ID.INPUT:
+        case TAG_ID.KEYGEN:
+        case TAG_ID.TEXTAREA:
+        case TAG_ID.SELECT: {
+            if (p.openElements.hasInSelectScope(TAG_ID.SELECT)) {
+                p.openElements.popUntilTagNamePopped(TAG_ID.SELECT);
+                p._resetInsertionMode();
+                if (token.tagID !== TAG_ID.SELECT) {
+                    p._processStartTag(token);
+                }
+            }
+            break;
+        }
+        case TAG_ID.SCRIPT:
+        case TAG_ID.TEMPLATE: {
+            startTagInHead(p, token);
+            break;
+        }
+        default:
+        // Do nothing
+    }
+}
+function endTagInSelect(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.OPTGROUP: {
+            if (p.openElements.stackTop > 0 &&
+                p.openElements.currentTagId === TAG_ID.OPTION &&
+                p.openElements.tagIDs[p.openElements.stackTop - 1] === TAG_ID.OPTGROUP) {
+                p.openElements.pop();
+            }
+            if (p.openElements.currentTagId === TAG_ID.OPTGROUP) {
+                p.openElements.pop();
+            }
+            break;
+        }
+        case TAG_ID.OPTION: {
+            if (p.openElements.currentTagId === TAG_ID.OPTION) {
+                p.openElements.pop();
+            }
+            break;
+        }
+        case TAG_ID.SELECT: {
+            if (p.openElements.hasInSelectScope(TAG_ID.SELECT)) {
+                p.openElements.popUntilTagNamePopped(TAG_ID.SELECT);
+                p._resetInsertionMode();
+            }
+            break;
+        }
+        case TAG_ID.TEMPLATE: {
+            templateEndTagInHead(p, token);
+            break;
+        }
+        default:
+        // Do nothing
+    }
+}
+// The "in select in table" insertion mode
+//------------------------------------------------------------------
+function startTagInSelectInTable(p, token) {
+    const tn = token.tagID;
+    if (tn === TAG_ID.CAPTION ||
+        tn === TAG_ID.TABLE ||
+        tn === TAG_ID.TBODY ||
+        tn === TAG_ID.TFOOT ||
+        tn === TAG_ID.THEAD ||
+        tn === TAG_ID.TR ||
+        tn === TAG_ID.TD ||
+        tn === TAG_ID.TH) {
+        p.openElements.popUntilTagNamePopped(TAG_ID.SELECT);
+        p._resetInsertionMode();
+        p._processStartTag(token);
+    }
+    else {
+        startTagInSelect(p, token);
+    }
+}
+function endTagInSelectInTable(p, token) {
+    const tn = token.tagID;
+    if (tn === TAG_ID.CAPTION ||
+        tn === TAG_ID.TABLE ||
+        tn === TAG_ID.TBODY ||
+        tn === TAG_ID.TFOOT ||
+        tn === TAG_ID.THEAD ||
+        tn === TAG_ID.TR ||
+        tn === TAG_ID.TD ||
+        tn === TAG_ID.TH) {
+        if (p.openElements.hasInTableScope(tn)) {
+            p.openElements.popUntilTagNamePopped(TAG_ID.SELECT);
+            p._resetInsertionMode();
+            p.onEndTag(token);
+        }
+    }
+    else {
+        endTagInSelect(p, token);
+    }
+}
+// The "in template" insertion mode
+//------------------------------------------------------------------
+function startTagInTemplate(p, token) {
+    switch (token.tagID) {
+        // First, handle tags that can start without a mode change
+        case TAG_ID.BASE:
+        case TAG_ID.BASEFONT:
+        case TAG_ID.BGSOUND:
+        case TAG_ID.LINK:
+        case TAG_ID.META:
+        case TAG_ID.NOFRAMES:
+        case TAG_ID.SCRIPT:
+        case TAG_ID.STYLE:
+        case TAG_ID.TEMPLATE:
+        case TAG_ID.TITLE: {
+            startTagInHead(p, token);
+            break;
+        }
+        // Re-process the token in the appropriate mode
+        case TAG_ID.CAPTION:
+        case TAG_ID.COLGROUP:
+        case TAG_ID.TBODY:
+        case TAG_ID.TFOOT:
+        case TAG_ID.THEAD: {
+            p.tmplInsertionModeStack[0] = InsertionMode.IN_TABLE;
+            p.insertionMode = InsertionMode.IN_TABLE;
+            startTagInTable(p, token);
+            break;
+        }
+        case TAG_ID.COL: {
+            p.tmplInsertionModeStack[0] = InsertionMode.IN_COLUMN_GROUP;
+            p.insertionMode = InsertionMode.IN_COLUMN_GROUP;
+            startTagInColumnGroup(p, token);
+            break;
+        }
+        case TAG_ID.TR: {
+            p.tmplInsertionModeStack[0] = InsertionMode.IN_TABLE_BODY;
+            p.insertionMode = InsertionMode.IN_TABLE_BODY;
+            startTagInTableBody(p, token);
+            break;
+        }
+        case TAG_ID.TD:
+        case TAG_ID.TH: {
+            p.tmplInsertionModeStack[0] = InsertionMode.IN_ROW;
+            p.insertionMode = InsertionMode.IN_ROW;
+            startTagInRow(p, token);
+            break;
+        }
+        default: {
+            p.tmplInsertionModeStack[0] = InsertionMode.IN_BODY;
+            p.insertionMode = InsertionMode.IN_BODY;
+            startTagInBody(p, token);
+        }
+    }
+}
+function endTagInTemplate(p, token) {
+    if (token.tagID === TAG_ID.TEMPLATE) {
+        templateEndTagInHead(p, token);
+    }
+}
+function eofInTemplate(p, token) {
+    if (p.openElements.tmplCount > 0) {
+        p.openElements.popUntilTagNamePopped(TAG_ID.TEMPLATE);
+        p.activeFormattingElements.clearToLastMarker();
+        p.tmplInsertionModeStack.shift();
+        p._resetInsertionMode();
+        p.onEof(token);
+    }
+    else {
+        stopParsing(p, token);
+    }
+}
+// The "after body" insertion mode
+//------------------------------------------------------------------
+function startTagAfterBody(p, token) {
+    if (token.tagID === TAG_ID.HTML) {
+        startTagInBody(p, token);
+    }
+    else {
+        tokenAfterBody(p, token);
+    }
+}
+function endTagAfterBody(p, token) {
+    var _a;
+    if (token.tagID === TAG_ID.HTML) {
+        if (!p.fragmentContext) {
+            p.insertionMode = InsertionMode.AFTER_AFTER_BODY;
+        }
+        //NOTE: <html> is never popped from the stack, so we need to updated
+        //the end location explicitly.
+        if (p.options.sourceCodeLocationInfo && p.openElements.tagIDs[0] === TAG_ID.HTML) {
+            p._setEndLocation(p.openElements.items[0], token);
+            // Update the body element, if it doesn't have an end tag
+            const bodyElement = p.openElements.items[1];
+            if (bodyElement && !((_a = p.treeAdapter.getNodeSourceCodeLocation(bodyElement)) === null || _a === void 0 ? void 0 : _a.endTag)) {
+                p._setEndLocation(bodyElement, token);
+            }
+        }
+    }
+    else {
+        tokenAfterBody(p, token);
+    }
+}
+function tokenAfterBody(p, token) {
+    p.insertionMode = InsertionMode.IN_BODY;
+    modeInBody(p, token);
+}
+// The "in frameset" insertion mode
+//------------------------------------------------------------------
+function startTagInFrameset(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.FRAMESET: {
+            p._insertElement(token, html_NS.HTML);
+            break;
+        }
+        case TAG_ID.FRAME: {
+            p._appendElement(token, html_NS.HTML);
+            token.ackSelfClosing = true;
+            break;
+        }
+        case TAG_ID.NOFRAMES: {
+            startTagInHead(p, token);
+            break;
+        }
+        default:
+        // Do nothing
+    }
+}
+function endTagInFrameset(p, token) {
+    if (token.tagID === TAG_ID.FRAMESET && !p.openElements.isRootHtmlElementCurrent()) {
+        p.openElements.pop();
+        if (!p.fragmentContext && p.openElements.currentTagId !== TAG_ID.FRAMESET) {
+            p.insertionMode = InsertionMode.AFTER_FRAMESET;
+        }
+    }
+}
+// The "after frameset" insertion mode
+//------------------------------------------------------------------
+function startTagAfterFrameset(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.NOFRAMES: {
+            startTagInHead(p, token);
+            break;
+        }
+        default:
+        // Do nothing
+    }
+}
+function endTagAfterFrameset(p, token) {
+    if (token.tagID === TAG_ID.HTML) {
+        p.insertionMode = InsertionMode.AFTER_AFTER_FRAMESET;
+    }
+}
+// The "after after body" insertion mode
+//------------------------------------------------------------------
+function startTagAfterAfterBody(p, token) {
+    if (token.tagID === TAG_ID.HTML) {
+        startTagInBody(p, token);
+    }
+    else {
+        tokenAfterAfterBody(p, token);
+    }
+}
+function tokenAfterAfterBody(p, token) {
+    p.insertionMode = InsertionMode.IN_BODY;
+    modeInBody(p, token);
+}
+// The "after after frameset" insertion mode
+//------------------------------------------------------------------
+function startTagAfterAfterFrameset(p, token) {
+    switch (token.tagID) {
+        case TAG_ID.HTML: {
+            startTagInBody(p, token);
+            break;
+        }
+        case TAG_ID.NOFRAMES: {
+            startTagInHead(p, token);
+            break;
+        }
+        default:
+        // Do nothing
+    }
+}
+// The rules for parsing tokens in foreign content
+//------------------------------------------------------------------
+function nullCharacterInForeignContent(p, token) {
+    token.chars = REPLACEMENT_CHARACTER;
+    p._insertCharacters(token);
+}
+function characterInForeignContent(p, token) {
+    p._insertCharacters(token);
+    p.framesetOk = false;
+}
+function popUntilHtmlOrIntegrationPoint(p) {
+    while (p.treeAdapter.getNamespaceURI(p.openElements.current) !== html_NS.HTML &&
+        !p._isIntegrationPoint(p.openElements.currentTagId, p.openElements.current)) {
+        p.openElements.pop();
+    }
+}
+function startTagInForeignContent(p, token) {
+    if (causesExit(token)) {
+        popUntilHtmlOrIntegrationPoint(p);
+        p._startTagOutsideForeignContent(token);
+    }
+    else {
+        const current = p._getAdjustedCurrentElement();
+        const currentNs = p.treeAdapter.getNamespaceURI(current);
+        if (currentNs === html_NS.MATHML) {
+            adjustTokenMathMLAttrs(token);
+        }
+        else if (currentNs === html_NS.SVG) {
+            adjustTokenSVGTagName(token);
+            adjustTokenSVGAttrs(token);
+        }
+        adjustTokenXMLAttrs(token);
+        if (token.selfClosing) {
+            p._appendElement(token, currentNs);
+        }
+        else {
+            p._insertElement(token, currentNs);
+        }
+        token.ackSelfClosing = true;
+    }
+}
+function endTagInForeignContent(p, token) {
+    if (token.tagID === TAG_ID.P || token.tagID === TAG_ID.BR) {
+        popUntilHtmlOrIntegrationPoint(p);
+        p._endTagOutsideForeignContent(token);
+        return;
+    }
+    for (let i = p.openElements.stackTop; i > 0; i--) {
+        const element = p.openElements.items[i];
+        if (p.treeAdapter.getNamespaceURI(element) === html_NS.HTML) {
+            p._endTagOutsideForeignContent(token);
+            break;
+        }
+        const tagName = p.treeAdapter.getTagName(element);
+        if (tagName.toLowerCase() === token.tagName) {
+            //NOTE: update the token tag name for `_setEndLocation`.
+            token.tagName = tagName;
+            p.openElements.shortenToLength(i);
+            break;
+        }
+    }
+}
+//# sourceMappingURL=index.js.map
+;// CONCATENATED MODULE: ./node_modules/entities/lib/esm/escape.js
+const xmlReplacer = /["&'<>$\x80-\uFFFF]/g;
+const xmlCodeMap = new Map([
+    [34, "&quot;"],
+    [38, "&amp;"],
+    [39, "&apos;"],
+    [60, "&lt;"],
+    [62, "&gt;"],
+]);
+// For compatibility with node < 4, we wrap `codePointAt`
+const getCodePoint = 
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+String.prototype.codePointAt != null
+    ? (str, index) => str.codePointAt(index)
+    : // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+        (c, index) => (c.charCodeAt(index) & 0xfc00) === 0xd800
+            ? (c.charCodeAt(index) - 0xd800) * 0x400 +
+                c.charCodeAt(index + 1) -
+                0xdc00 +
+                0x10000
+            : c.charCodeAt(index);
+/**
+ * Encodes all non-ASCII characters, as well as characters not valid in XML
+ * documents using XML entities.
+ *
+ * If a character has no equivalent entity, a
+ * numeric hexadecimal reference (eg. `&#xfc;`) will be used.
+ */
+function encodeXML(str) {
+    let ret = "";
+    let lastIdx = 0;
+    let match;
+    while ((match = xmlReplacer.exec(str)) !== null) {
+        const i = match.index;
+        const char = str.charCodeAt(i);
+        const next = xmlCodeMap.get(char);
+        if (next !== undefined) {
+            ret += str.substring(lastIdx, i) + next;
+            lastIdx = i + 1;
+        }
+        else {
+            ret += `${str.substring(lastIdx, i)}&#x${getCodePoint(str, i).toString(16)};`;
+            // Increase by 1 if we have a surrogate pair
+            lastIdx = xmlReplacer.lastIndex += Number((char & 0xfc00) === 0xd800);
+        }
+    }
+    return ret + str.substr(lastIdx);
+}
+/**
+ * Encodes all non-ASCII characters, as well as characters not valid in XML
+ * documents using numeric hexadecimal reference (eg. `&#xfc;`).
+ *
+ * Have a look at `escapeUTF8` if you want a more concise output at the expense
+ * of reduced transportability.
+ *
+ * @param data String to escape.
+ */
+const escape_escape = (/* unused pure expression or super */ null && (encodeXML));
+/**
+ * Creates a function that escapes all characters matched by the given regular
+ * expression using the given map of characters to escape to their entities.
+ *
+ * @param regex Regular expression to match characters to escape.
+ * @param map Map of characters to escape to their entities.
+ *
+ * @returns Function that escapes all characters matched by the given regular
+ * expression using the given map of characters to escape to their entities.
+ */
+function getEscaper(regex, map) {
+    return function escape(data) {
+        let match;
+        let lastIdx = 0;
+        let result = "";
+        while ((match = regex.exec(data))) {
+            if (lastIdx !== match.index) {
+                result += data.substring(lastIdx, match.index);
+            }
+            // We know that this character will be in the map.
+            result += map.get(match[0].charCodeAt(0));
+            // Every match will be of length 1
+            lastIdx = match.index + 1;
+        }
+        return result + data.substring(lastIdx);
+    };
+}
+/**
+ * Encodes all characters not valid in XML documents using XML entities.
+ *
+ * Note that the output will be character-set dependent.
+ *
+ * @param data String to escape.
+ */
+const escapeUTF8 = getEscaper(/[&<>'"]/g, xmlCodeMap);
+/**
+ * Encodes all characters that have to be escaped in HTML attributes,
+ * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
+ *
+ * @param data String to escape.
+ */
+const escape_escapeAttribute = getEscaper(/["&\u00A0]/g, new Map([
+    [34, "&quot;"],
+    [38, "&amp;"],
+    [160, "&nbsp;"],
+]));
+/**
+ * Encodes all characters that have to be escaped in HTML text,
+ * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
+ *
+ * @param data String to escape.
+ */
+const escape_escapeText = getEscaper(/[&<>\u00A0]/g, new Map([
+    [38, "&amp;"],
+    [60, "&lt;"],
+    [62, "&gt;"],
+    [160, "&nbsp;"],
+]));
+//# sourceMappingURL=escape.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/serializer/index.js
+
+
+
+// Sets
+const VOID_ELEMENTS = new Set([
+    TAG_NAMES.AREA,
+    TAG_NAMES.BASE,
+    TAG_NAMES.BASEFONT,
+    TAG_NAMES.BGSOUND,
+    TAG_NAMES.BR,
+    TAG_NAMES.COL,
+    TAG_NAMES.EMBED,
+    TAG_NAMES.FRAME,
+    TAG_NAMES.HR,
+    TAG_NAMES.IMG,
+    TAG_NAMES.INPUT,
+    TAG_NAMES.KEYGEN,
+    TAG_NAMES.LINK,
+    TAG_NAMES.META,
+    TAG_NAMES.PARAM,
+    TAG_NAMES.SOURCE,
+    TAG_NAMES.TRACK,
+    TAG_NAMES.WBR,
+]);
+function isVoidElement(node, options) {
+    return (options.treeAdapter.isElementNode(node) &&
+        options.treeAdapter.getNamespaceURI(node) === NS.HTML &&
+        VOID_ELEMENTS.has(options.treeAdapter.getTagName(node)));
+}
+const defaultOpts = { treeAdapter: defaultTreeAdapter, scriptingEnabled: true };
+/**
+ * Serializes an AST node to an HTML string.
+ *
+ * @example
+ *
+ * ```js
+ * const parse5 = require('parse5');
+ *
+ * const document = parse5.parse('<!DOCTYPE html><html><head></head><body>Hi there!</body></html>');
+ *
+ * // Serializes a document.
+ * const html = parse5.serialize(document);
+ *
+ * // Serializes the <html> element content.
+ * const str = parse5.serialize(document.childNodes[1]);
+ *
+ * console.log(str); //> '<head></head><body>Hi there!</body>'
+ * ```
+ *
+ * @param node Node to serialize.
+ * @param options Serialization options.
+ */
+function serialize(node, options) {
+    const opts = { ...defaultOpts, ...options };
+    if (isVoidElement(node, opts)) {
+        return '';
+    }
+    return serializeChildNodes(node, opts);
+}
+/**
+ * Serializes an AST element node to an HTML string, including the element node.
+ *
+ * @example
+ *
+ * ```js
+ * const parse5 = require('parse5');
+ *
+ * const document = parse5.parseFragment('<div>Hello, <b>world</b>!</div>');
+ *
+ * // Serializes the <div> element.
+ * const html = parse5.serializeOuter(document.childNodes[0]);
+ *
+ * console.log(str); //> '<div>Hello, <b>world</b>!</div>'
+ * ```
+ *
+ * @param node Node to serialize.
+ * @param options Serialization options.
+ */
+function serializeOuter(node, options) {
+    const opts = { ...defaultOpts, ...options };
+    return serializeNode(node, opts);
+}
+function serializeChildNodes(parentNode, options) {
+    let html = '';
+    // Get container of the child nodes
+    const container = options.treeAdapter.isElementNode(parentNode) &&
+        options.treeAdapter.getTagName(parentNode) === $.TEMPLATE &&
+        options.treeAdapter.getNamespaceURI(parentNode) === NS.HTML
+        ? options.treeAdapter.getTemplateContent(parentNode)
+        : parentNode;
+    const childNodes = options.treeAdapter.getChildNodes(container);
+    if (childNodes) {
+        for (const currentNode of childNodes) {
+            html += serializeNode(currentNode, options);
+        }
+    }
+    return html;
+}
+function serializeNode(node, options) {
+    if (options.treeAdapter.isElementNode(node)) {
+        return serializeElement(node, options);
+    }
+    if (options.treeAdapter.isTextNode(node)) {
+        return serializeTextNode(node, options);
+    }
+    if (options.treeAdapter.isCommentNode(node)) {
+        return serializeCommentNode(node, options);
+    }
+    if (options.treeAdapter.isDocumentTypeNode(node)) {
+        return serializeDocumentTypeNode(node, options);
+    }
+    // Return an empty string for unknown nodes
+    return '';
+}
+function serializeElement(node, options) {
+    const tn = options.treeAdapter.getTagName(node);
+    return `<${tn}${serializer_serializeAttributes(node, options)}>${isVoidElement(node, options) ? '' : `${serializeChildNodes(node, options)}</${tn}>`}`;
+}
+function serializer_serializeAttributes(node, { treeAdapter }) {
+    let html = '';
+    for (const attr of treeAdapter.getAttrList(node)) {
+        html += ' ';
+        if (!attr.namespace) {
+            html += attr.name;
+        }
+        else
+            switch (attr.namespace) {
+                case NS.XML: {
+                    html += `xml:${attr.name}`;
+                    break;
+                }
+                case NS.XMLNS: {
+                    if (attr.name !== 'xmlns') {
+                        html += 'xmlns:';
+                    }
+                    html += attr.name;
+                    break;
+                }
+                case NS.XLINK: {
+                    html += `xlink:${attr.name}`;
+                    break;
+                }
+                default: {
+                    html += `${attr.prefix}:${attr.name}`;
+                }
+            }
+        html += `="${escapeAttribute(attr.value)}"`;
+    }
+    return html;
+}
+function serializeTextNode(node, options) {
+    const { treeAdapter } = options;
+    const content = treeAdapter.getTextNodeContent(node);
+    const parent = treeAdapter.getParentNode(node);
+    const parentTn = parent && treeAdapter.isElementNode(parent) && treeAdapter.getTagName(parent);
+    return parentTn &&
+        treeAdapter.getNamespaceURI(parent) === NS.HTML &&
+        hasUnescapedText(parentTn, options.scriptingEnabled)
+        ? content
+        : escapeText(content);
+}
+function serializeCommentNode(node, { treeAdapter }) {
+    return `<!--${treeAdapter.getCommentNodeContent(node)}-->`;
+}
+function serializeDocumentTypeNode(node, { treeAdapter }) {
+    return `<!DOCTYPE ${treeAdapter.getDocumentTypeNodeName(node)}>`;
+}
+//# sourceMappingURL=index.js.map
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/node_modules/parse5/dist/index.js
+
+
+
+
+
+/** @internal */
+
+/** @internal */
+
+/** @internal */
+
+/** @internal */
+
+// Shorthands
+/**
+ * Parses an HTML string.
+ *
+ * @param html Input HTML string.
+ * @param options Parsing options.
+ * @returns Document
+ *
+ * @example
+ *
+ * ```js
+ * const parse5 = require('parse5');
+ *
+ * const document = parse5.parse('<!DOCTYPE html><html><head></head><body>Hi there!</body></html>');
+ *
+ * console.log(document.childNodes[1].tagName); //> 'html'
+ *```
+ */
+function dist_parse(html, options) {
+    return Parser.parse(html, options);
+}
+function parseFragment(fragmentContext, html, options) {
+    if (typeof fragmentContext === 'string') {
+        options = html;
+        html = fragmentContext;
+        fragmentContext = null;
+    }
+    const parser = Parser.getFragmentParser(fragmentContext, options);
+    parser.tokenizer.write(html, true);
+    return parser.getFragment();
+}
+//# sourceMappingURL=index.js.map
+// EXTERNAL MODULE: ./node_modules/is-buffer/index.js
+var is_buffer = __nccwpck_require__(5625);
+;// CONCATENATED MODULE: ./node_modules/unist-util-stringify-position/lib/index.js
+/**
+ * @typedef {import('unist').Node} Node
+ * @typedef {import('unist').Point} Point
+ * @typedef {import('unist').Position} Position
+ */
+
+/**
+ * @typedef NodeLike
+ * @property {string} type
+ * @property {PositionLike | null | undefined} [position]
+ *
+ * @typedef PositionLike
+ * @property {PointLike | null | undefined} [start]
+ * @property {PointLike | null | undefined} [end]
+ *
+ * @typedef PointLike
+ * @property {number | null | undefined} [line]
+ * @property {number | null | undefined} [column]
+ * @property {number | null | undefined} [offset]
+ */
+
+/**
+ * Serialize the positional info of a point, position (start and end points),
+ * or node.
+ *
+ * @param {Node | NodeLike | Position | PositionLike | Point | PointLike | null | undefined} [value]
+ *   Node, position, or point.
+ * @returns {string}
+ *   Pretty printed positional info of a node (`string`).
+ *
+ *   In the format of a range `ls:cs-le:ce` (when given `node` or `position`)
+ *   or a point `l:c` (when given `point`), where `l` stands for line, `c` for
+ *   column, `s` for `start`, and `e` for end.
+ *   An empty string (`''`) is returned if the given value is neither `node`,
+ *   `position`, nor `point`.
+ */
+function stringifyPosition(value) {
+  // Nothing.
+  if (!value || typeof value !== 'object') {
+    return ''
+  }
+
+  // Node.
+  if ('position' in value || 'type' in value) {
+    return position(value.position)
+  }
+
+  // Position.
+  if ('start' in value || 'end' in value) {
+    return position(value)
+  }
+
+  // Point.
+  if ('line' in value || 'column' in value) {
+    return point(value)
+  }
+
+  // ?
+  return ''
+}
+
+/**
+ * @param {Point | PointLike | null | undefined} point
+ * @returns {string}
+ */
+function point(point) {
+  return index(point && point.line) + ':' + index(point && point.column)
+}
+
+/**
+ * @param {Position | PositionLike | null | undefined} pos
+ * @returns {string}
+ */
+function position(pos) {
+  return point(pos && pos.start) + '-' + point(pos && pos.end)
+}
+
+/**
+ * @param {number | null | undefined} value
+ * @returns {number}
+ */
+function index(value) {
+  return value && typeof value === 'number' ? value : 1
+}
+
+;// CONCATENATED MODULE: ./node_modules/vfile-message/index.js
+/**
+ * @typedef {import('unist').Node} Node
+ * @typedef {import('unist').Position} Position
+ * @typedef {import('unist').Point} Point
+ * @typedef {object & {type: string, position?: Position|undefined}} NodeLike
+ */
+
+
+
+class VFileMessage extends Error {
+  /**
+   * Create a message for `reason` at `place` from `origin`.
+   *
+   * When an error is passed in as `reason`, the `stack` is copied.
+   *
+   * @param {string|Error|VFileMessage} reason
+   *   Reason for message.
+   *   Uses the stack and message of the error if given.
+   * @param {Node|NodeLike|Position|Point} [place]
+   *   Place at which the message occurred in a file.
+   * @param {string} [origin]
+   *   Place in code the message originates from (example `'my-package:my-rule-name'`)
+   */
+  constructor(reason, place, origin) {
+    /** @type {[string|null, string|null]} */
+    const parts = [null, null]
+    /** @type {Position} */
+    let position = {
+      // @ts-expect-error: we always follows the structure of `position`.
+      start: {line: null, column: null},
+      // @ts-expect-error: "
+      end: {line: null, column: null}
+    }
+
+    super()
+
+    if (typeof place === 'string') {
+      origin = place
+      place = undefined
+    }
+
+    if (typeof origin === 'string') {
+      const index = origin.indexOf(':')
+
+      if (index === -1) {
+        parts[1] = origin
+      } else {
+        parts[0] = origin.slice(0, index)
+        parts[1] = origin.slice(index + 1)
+      }
+    }
+
+    if (place) {
+      // Node.
+      if ('type' in place || 'position' in place) {
+        if (place.position) {
+          // @ts-expect-error: looks like a position.
+          position = place.position
+        }
+      }
+      // Position.
+      else if ('start' in place || 'end' in place) {
+        // @ts-expect-error: looks like a position.
+        position = place
+      }
+      // Point.
+      else if ('line' in place || 'column' in place) {
+        position.start = place
+      }
+    }
+
+    // Fields from `Error`
+    this.name = stringifyPosition(place) || '1:1'
+    /** @type {string} */
+    this.message = typeof reason === 'object' ? reason.message : reason
+    /** @type {string} */
+    this.stack = ''
+
+    if (typeof reason === 'object' && reason.stack) {
+      this.stack = reason.stack
+    }
+
+    /**
+     * Reason for message.
+     *
+     * @type {string}
+     */
+    this.reason = this.message
+
+    /* eslint-disable no-unused-expressions */
+    /**
+     * Whether this is a fatal problem that marks an associated file as no
+     * longer processable.
+     * If `true`, marks associated file as no longer processable.
+     * If `false`, necessitates a (potential) change.
+     * The value can also be `null` or `undefined`, for things that might not
+     * need changing.
+     *
+     * @type {boolean?}
+     */
+    this.fatal
+
+    /**
+     * Starting line of error.
+     *
+     * @type {number?}
+     */
+    this.line = position.start.line
+
+    /**
+     * Starting column of error.
+     *
+     * @type {number?}
+     */
+    this.column = position.start.column
+
+    /**
+     * Full range information, when available.
+     * Has `start` and `end` fields, both set to an object with `line` and
+     * `column`, set to `number?`.
+     *
+     * @type {Position?}
+     */
+    this.position = position
+
+    /**
+     * Namespace of warning (example: `'my-package'`).
+     *
+     * @type {string?}
+     */
+    this.source = parts[0]
+
+    /**
+     * Category of message (example: `'my-rule-name'`).
+     *
+     * @type {string?}
+     */
+    this.ruleId = parts[1]
+
+    /**
+     * Path of a file (used throughout the VFile ecosystem).
+     *
+     * @type {string?}
+     */
+    this.file
+
+    // The following fields are “well known”.
+    // Not standard.
+    // Feel free to add other non-standard fields to your messages.
+
+    /**
+     * Specify the source value that’s being reported, which is deemed
+     * incorrect.
+     *
+     * @type {string?}
+     */
+    this.actual
+
+    /**
+     * Suggest values that should be used instead of `actual`, one or more
+     * values that are deemed as acceptable.
+     *
+     * @type {Array<string>?}
+     */
+    this.expected
+
+    /**
+     * Link to documentation for the message.
+     *
+     * @type {string?}
+     */
+    this.url
+
+    /**
+     * Long form description of the message (supported by `vfile-reporter`).
+     *
+     * @type {string?}
+     */
+    this.note
+    /* eslint-enable no-unused-expressions */
+  }
+}
+
+VFileMessage.prototype.file = ''
+VFileMessage.prototype.name = ''
+VFileMessage.prototype.reason = ''
+VFileMessage.prototype.message = ''
+VFileMessage.prototype.stack = ''
+VFileMessage.prototype.fatal = null
+VFileMessage.prototype.column = null
+VFileMessage.prototype.line = null
+VFileMessage.prototype.source = null
+VFileMessage.prototype.ruleId = null
+VFileMessage.prototype.position = null
+
+// EXTERNAL MODULE: external "path"
+var external_path_ = __nccwpck_require__(1017);
+;// CONCATENATED MODULE: external "process"
+const external_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("process");
+;// CONCATENATED MODULE: ./node_modules/vfile/lib/minurl.shared.js
+/**
+ * @typedef URL
+ * @property {string} hash
+ * @property {string} host
+ * @property {string} hostname
+ * @property {string} href
+ * @property {string} origin
+ * @property {string} password
+ * @property {string} pathname
+ * @property {string} port
+ * @property {string} protocol
+ * @property {string} search
+ * @property {any} searchParams
+ * @property {string} username
+ * @property {() => string} toString
+ * @property {() => string} toJSON
+ */
+
+/**
+ * @param {unknown} fileURLOrPath
+ * @returns {fileURLOrPath is URL}
+ */
+// From: <https://github.com/nodejs/node/blob/fcf8ba4/lib/internal/url.js#L1501>
+function isUrl(fileURLOrPath) {
+  return (
+    fileURLOrPath !== null &&
+    typeof fileURLOrPath === 'object' &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.href &&
+    // @ts-expect-error: indexable.
+    fileURLOrPath.origin
+  )
+}
+
+// EXTERNAL MODULE: external "url"
+var external_url_ = __nccwpck_require__(7310);
+;// CONCATENATED MODULE: ./node_modules/vfile/lib/index.js
+/**
+ * @typedef {import('unist').Node} Node
+ * @typedef {import('unist').Position} Position
+ * @typedef {import('unist').Point} Point
+ * @typedef {Record<string, unknown> & {type: string, position?: Position|undefined}} NodeLike
+ * @typedef {import('./minurl.shared.js').URL} URL
+ * @typedef {import('../index.js').Data} Data
+ * @typedef {import('../index.js').Value} Value
+ *
+ * @typedef {'ascii'|'utf8'|'utf-8'|'utf16le'|'ucs2'|'ucs-2'|'base64'|'base64url'|'latin1'|'binary'|'hex'} BufferEncoding
+ *   Encodings supported by the buffer class.
+ *   This is a copy of the typing from Node, copied to prevent Node globals from
+ *   being needed.
+ *   Copied from: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/90a4ec8/types/node/buffer.d.ts#L170>
+ *
+ * @typedef {Value|Options|VFile|URL} Compatible
+ *   Things that can be passed to the constructor.
+ *
+ * @typedef VFileCoreOptions
+ * @property {Value} [value]
+ * @property {string} [cwd]
+ * @property {Array<string>} [history]
+ * @property {string|URL} [path]
+ * @property {string} [basename]
+ * @property {string} [stem]
+ * @property {string} [extname]
+ * @property {string} [dirname]
+ * @property {Data} [data]
+ *
+ * @typedef Map
+ *   Raw source map, see:
+ *   <https://github.com/mozilla/source-map/blob/58819f0/source-map.d.ts#L15-L23>.
+ * @property {number} version
+ * @property {Array<string>} sources
+ * @property {Array<string>} names
+ * @property {string|undefined} [sourceRoot]
+ * @property {Array<string>|undefined} [sourcesContent]
+ * @property {string} mappings
+ * @property {string} file
+ *
+ * @typedef {{[key: string]: unknown} & VFileCoreOptions} Options
+ *   Configuration: a bunch of keys that will be shallow copied over to the new
+ *   file.
+ *
+ * @typedef {Record<string, unknown>} ReporterSettings
+ * @typedef {<T = ReporterSettings>(files: Array<VFile>, options: T) => string} Reporter
+ */
+
+
+
+
+
+
+
+// Order of setting (least specific to most), we need this because otherwise
+// `{stem: 'a', path: '~/b.js'}` would throw, as a path is needed before a
+// stem can be set.
+const order = ['history', 'path', 'basename', 'stem', 'extname', 'dirname']
+
+class VFile {
+  /**
+   * Create a new virtual file.
+   *
+   * If `options` is `string` or `Buffer`, it’s treated as `{value: options}`.
+   * If `options` is a `URL`, it’s treated as `{path: options}`.
+   * If `options` is a `VFile`, shallow copies its data over to the new file.
+   * All fields in `options` are set on the newly created `VFile`.
+   *
+   * Path related fields are set in the following order (least specific to
+   * most specific): `history`, `path`, `basename`, `stem`, `extname`,
+   * `dirname`.
+   *
+   * It’s not possible to set either `dirname` or `extname` without setting
+   * either `history`, `path`, `basename`, or `stem` as well.
+   *
+   * @param {Compatible} [value]
+   */
+  constructor(value) {
+    /** @type {Options} */
+    let options
+
+    if (!value) {
+      options = {}
+    } else if (typeof value === 'string' || is_buffer(value)) {
+      // @ts-expect-error Looks like a buffer.
+      options = {value}
+    } else if (isUrl(value)) {
+      options = {path: value}
+    } else {
+      // @ts-expect-error Looks like file or options.
+      options = value
+    }
+
+    /**
+     * Place to store custom information (default: `{}`).
+     * It’s OK to store custom data directly on the file but moving it to
+     * `data` is recommended.
+     * @type {Data}
+     */
+    this.data = {}
+
+    /**
+     * List of messages associated with the file.
+     * @type {Array<VFileMessage>}
+     */
+    this.messages = []
+
+    /**
+     * List of filepaths the file moved between.
+     * The first is the original path and the last is the current path.
+     * @type {Array<string>}
+     */
+    this.history = []
+
+    /**
+     * Base of `path` (default: `process.cwd()` or `'/'` in browsers).
+     * @type {string}
+     */
+    this.cwd = external_process_namespaceObject.cwd()
+
+    /* eslint-disable no-unused-expressions */
+    /**
+     * Raw value.
+     * @type {Value}
+     */
+    this.value
+
+    // The below are non-standard, they are “well-known”.
+    // As in, used in several tools.
+
+    /**
+     * Whether a file was saved to disk.
+     * This is used by vfile reporters.
+     * @type {boolean}
+     */
+    this.stored
+
+    /**
+     * Sometimes files have a non-string, compiled, representation.
+     * This can be stored in the `result` field.
+     * One example is when turning markdown into React nodes.
+     * This is used by unified to store non-string results.
+     * @type {unknown}
+     */
+    this.result
+
+    /**
+     * Sometimes files have a source map associated with them.
+     * This can be stored in the `map` field.
+     * This should be a `Map` type, which is equivalent to the `RawSourceMap`
+     * type from the `source-map` module.
+     * @type {Map|undefined}
+     */
+    this.map
+    /* eslint-enable no-unused-expressions */
+
+    // Set path related properties in the correct order.
+    let index = -1
+
+    while (++index < order.length) {
+      const prop = order[index]
+
+      // Note: we specifically use `in` instead of `hasOwnProperty` to accept
+      // `vfile`s too.
+      if (prop in options && options[prop] !== undefined) {
+        // @ts-expect-error: TS is confused by the different types for `history`.
+        this[prop] = prop === 'history' ? [...options[prop]] : options[prop]
+      }
+    }
+
+    /** @type {string} */
+    let prop
+
+    // Set non-path related properties.
+    for (prop in options) {
+      // @ts-expect-error: fine to set other things.
+      if (!order.includes(prop)) this[prop] = options[prop]
+    }
+  }
+
+  /**
+   * Get the full path (example: `'~/index.min.js'`).
+   * @returns {string}
+   */
+  get path() {
+    return this.history[this.history.length - 1]
+  }
+
+  /**
+   * Set the full path (example: `'~/index.min.js'`).
+   * Cannot be nullified.
+   * You can set a file URL (a `URL` object with a `file:` protocol) which will
+   * be turned into a path with `url.fileURLToPath`.
+   * @param {string|URL} path
+   */
+  set path(path) {
+    if (isUrl(path)) {
+      path = (0,external_url_.fileURLToPath)(path)
+    }
+
+    assertNonEmpty(path, 'path')
+
+    if (this.path !== path) {
+      this.history.push(path)
+    }
+  }
+
+  /**
+   * Get the parent path (example: `'~'`).
+   */
+  get dirname() {
+    return typeof this.path === 'string' ? external_path_.dirname(this.path) : undefined
+  }
+
+  /**
+   * Set the parent path (example: `'~'`).
+   * Cannot be set if there’s no `path` yet.
+   */
+  set dirname(dirname) {
+    assertPath(this.basename, 'dirname')
+    this.path = external_path_.join(dirname || '', this.basename)
+  }
+
+  /**
+   * Get the basename (including extname) (example: `'index.min.js'`).
+   */
+  get basename() {
+    return typeof this.path === 'string' ? external_path_.basename(this.path) : undefined
+  }
+
+  /**
+   * Set basename (including extname) (`'index.min.js'`).
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be nullified (use `file.path = file.dirname` instead).
+   */
+  set basename(basename) {
+    assertNonEmpty(basename, 'basename')
+    assertPart(basename, 'basename')
+    this.path = external_path_.join(this.dirname || '', basename)
+  }
+
+  /**
+   * Get the extname (including dot) (example: `'.js'`).
+   */
+  get extname() {
+    return typeof this.path === 'string' ? external_path_.extname(this.path) : undefined
+  }
+
+  /**
+   * Set the extname (including dot) (example: `'.js'`).
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be set if there’s no `path` yet.
+   */
+  set extname(extname) {
+    assertPart(extname, 'extname')
+    assertPath(this.dirname, 'extname')
+
+    if (extname) {
+      if (extname.charCodeAt(0) !== 46 /* `.` */) {
+        throw new Error('`extname` must start with `.`')
+      }
+
+      if (extname.includes('.', 1)) {
+        throw new Error('`extname` cannot contain multiple dots')
+      }
+    }
+
+    this.path = external_path_.join(this.dirname, this.stem + (extname || ''))
+  }
+
+  /**
+   * Get the stem (basename w/o extname) (example: `'index.min'`).
+   */
+  get stem() {
+    return typeof this.path === 'string'
+      ? external_path_.basename(this.path, this.extname)
+      : undefined
+  }
+
+  /**
+   * Set the stem (basename w/o extname) (example: `'index.min'`).
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be nullified (use `file.path = file.dirname` instead).
+   */
+  set stem(stem) {
+    assertNonEmpty(stem, 'stem')
+    assertPart(stem, 'stem')
+    this.path = external_path_.join(this.dirname || '', stem + (this.extname || ''))
+  }
+
+  /**
+   * Serialize the file.
+   *
+   * @param {BufferEncoding} [encoding='utf8']
+   *   When `value` is a `Buffer`, `encoding` is a character encoding to
+   *   understand it as (default: `'utf8'`).
+   * @returns {string}
+   *   Serialized file.
+   */
+  toString(encoding) {
+    return (this.value || '').toString(encoding)
+  }
+
+  /**
+   * Constructs a new `VFileMessage`, where `fatal` is set to `false`, and
+   * associates it with the file by adding it to `vfile.messages` and setting
+   * `message.file` to the current filepath.
+   *
+   * @param {string|Error|VFileMessage} reason
+   *   Human readable reason for the message, uses the stack and message of the error if given.
+   * @param {Node|NodeLike|Position|Point} [place]
+   *   Place where the message occurred in the file.
+   * @param {string} [origin]
+   *   Computer readable reason for the message
+   * @returns {VFileMessage}
+   *   Message.
+   */
+  message(reason, place, origin) {
+    const message = new VFileMessage(reason, place, origin)
+
+    if (this.path) {
+      message.name = this.path + ':' + message.name
+      message.file = this.path
+    }
+
+    message.fatal = false
+
+    this.messages.push(message)
+
+    return message
+  }
+
+  /**
+   * Like `VFile#message()`, but associates an informational message where
+   * `fatal` is set to `null`.
+   *
+   * @param {string|Error|VFileMessage} reason
+   *   Human readable reason for the message, uses the stack and message of the error if given.
+   * @param {Node|NodeLike|Position|Point} [place]
+   *   Place where the message occurred in the file.
+   * @param {string} [origin]
+   *   Computer readable reason for the message
+   * @returns {VFileMessage}
+   *   Message.
+   */
+  info(reason, place, origin) {
+    const message = this.message(reason, place, origin)
+
+    message.fatal = null
+
+    return message
+  }
+
+  /**
+   * Like `VFile#message()`, but associates a fatal message where `fatal` is
+   * set to `true`, and then immediately throws it.
+   *
+   * > 👉 **Note**: a fatal error means that a file is no longer processable.
+   *
+   * @param {string|Error|VFileMessage} reason
+   *   Human readable reason for the message, uses the stack and message of the error if given.
+   * @param {Node|NodeLike|Position|Point} [place]
+   *   Place where the message occurred in the file.
+   * @param {string} [origin]
+   *   Computer readable reason for the message
+   * @returns {never}
+   *   Message.
+   */
+  fail(reason, place, origin) {
+    const message = this.message(reason, place, origin)
+
+    message.fatal = true
+
+    throw message
+  }
+}
+
+/**
+ * Assert that `part` is not a path (as in, does not contain `path.sep`).
+ *
+ * @param {string|undefined} part
+ * @param {string} name
+ * @returns {void}
+ */
+function assertPart(part, name) {
+  if (part && part.includes(external_path_.sep)) {
+    throw new Error(
+      '`' + name + '` cannot be a path: did not expect `' + external_path_.sep + '`'
+    )
+  }
+}
+
+/**
+ * Assert that `part` is not empty.
+ *
+ * @param {string|undefined} part
+ * @param {string} name
+ * @returns {asserts part is string}
+ */
+function assertNonEmpty(part, name) {
+  if (!part) {
+    throw new Error('`' + name + '` cannot be empty')
+  }
+}
+
+/**
+ * Assert `path` exists.
+ *
+ * @param {string|undefined} path
+ * @param {string} name
+ * @returns {asserts path is string}
+ */
+function assertPath(path, name) {
+  if (!path) {
+    throw new Error('Setting `' + name + '` requires `path` to be set too')
+  }
+}
+
+;// CONCATENATED MODULE: ./node_modules/hastscript/lib/svg-case-sensitive-tag-names.js
+const svgCaseSensitiveTagNames = [
+  'altGlyph',
+  'altGlyphDef',
+  'altGlyphItem',
+  'animateColor',
+  'animateMotion',
+  'animateTransform',
+  'clipPath',
+  'feBlend',
+  'feColorMatrix',
+  'feComponentTransfer',
+  'feComposite',
+  'feConvolveMatrix',
+  'feDiffuseLighting',
+  'feDisplacementMap',
+  'feDistantLight',
+  'feDropShadow',
+  'feFlood',
+  'feFuncA',
+  'feFuncB',
+  'feFuncG',
+  'feFuncR',
+  'feGaussianBlur',
+  'feImage',
+  'feMerge',
+  'feMergeNode',
+  'feMorphology',
+  'feOffset',
+  'fePointLight',
+  'feSpecularLighting',
+  'feSpotLight',
+  'feTile',
+  'feTurbulence',
+  'foreignObject',
+  'glyphRef',
+  'linearGradient',
+  'radialGradient',
+  'solidColor',
+  'textArea',
+  'textPath'
+]
+
+;// CONCATENATED MODULE: ./node_modules/hastscript/lib/svg.js
+/**
+ * @typedef {import('./core.js').HChild} Child
+ *   Acceptable child value.
+ * @typedef {import('./core.js').HProperties} Properties
+ *   Acceptable value for element properties.
+ * @typedef {import('./core.js').HResult} Result
+ *   Result from a `h` (or `s`) call.
+ *
+ * @typedef {import('./jsx-classic.js').Element} s.JSX.Element
+ * @typedef {import('./jsx-classic.js').IntrinsicAttributes} s.JSX.IntrinsicAttributes
+ * @typedef {import('./jsx-classic.js').IntrinsicElements} s.JSX.IntrinsicElements
+ * @typedef {import('./jsx-classic.js').ElementChildrenAttribute} s.JSX.ElementChildrenAttribute
+ */
+
+
+
+
+
+const s = lib_core_core(property_information_svg, 'g', svgCaseSensitiveTagNames)
+
+;// CONCATENATED MODULE: ./node_modules/vfile-location/index.js
+/**
+ * @typedef {import('unist').Point} Point
+ * @typedef {import('vfile').VFile} VFile
+ *
+ * @typedef {Pick<Point, 'line'|'column'>} PositionalPoint
+ * @typedef {Required<Point>} FullPoint
+ * @typedef {NonNullable<Point['offset']>} Offset
+ */
+
+/**
+ * Get transform functions for the given `document`.
+ *
+ * @param {string|Uint8Array|VFile} file
+ */
+function vfile_location_location(file) {
+  var value = String(file)
+  /** @type {Array.<number>} */
+  var indices = []
+  var search = /\r?\n|\r/g
+
+  while (search.test(value)) {
+    indices.push(search.lastIndex)
+  }
+
+  indices.push(value.length + 1)
+
+  return {toPoint, toOffset}
+
+  /**
+   * Get the line and column-based `point` for `offset` in the bound indices.
+   * Returns a point with `undefined` values when given invalid or out of bounds
+   * input.
+   *
+   * @param {Offset} offset
+   * @returns {FullPoint}
+   */
+  function toPoint(offset) {
+    var index = -1
+
+    if (offset > -1 && offset < indices[indices.length - 1]) {
+      while (++index < indices.length) {
+        if (indices[index] > offset) {
+          return {
+            line: index + 1,
+            column: offset - (indices[index - 1] || 0) + 1,
+            offset
+          }
+        }
+      }
+    }
+
+    return {line: undefined, column: undefined, offset: undefined}
+  }
+
+  /**
+   * Get the `offset` for a line and column-based `point` in the bound indices.
+   * Returns `-1` when given invalid or out of bounds input.
+   *
+   * @param {PositionalPoint} point
+   * @returns {Offset}
+   */
+  function toOffset(point) {
+    var line = point && point.line
+    var column = point && point.column
+    /** @type {number} */
+    var offset
+
+    if (
+      typeof line === 'number' &&
+      typeof column === 'number' &&
+      !Number.isNaN(line) &&
+      !Number.isNaN(column) &&
+      line - 1 in indices
+    ) {
+      offset = (indices[line - 2] || 0) + column - 1 || 0
+    }
+
+    return offset > -1 && offset < indices[indices.length - 1] ? offset : -1
+  }
+}
+
+;// CONCATENATED MODULE: ./node_modules/web-namespaces/index.js
+/**
+ * Map of web namespaces.
+ *
+ * @type {Record<string, string>}
+ */
+const webNamespaces = {
+  html: 'http://www.w3.org/1999/xhtml',
+  mathml: 'http://www.w3.org/1998/Math/MathML',
+  svg: 'http://www.w3.org/2000/svg',
+  xlink: 'http://www.w3.org/1999/xlink',
+  xml: 'http://www.w3.org/XML/1998/namespace',
+  xmlns: 'http://www.w3.org/2000/xmlns/'
+}
+
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-parse5/lib/index.js
+/**
+ * @typedef {import('vfile').VFile} VFile
+ * @typedef {import('property-information').Schema} Schema
+ * @typedef {import('unist').Position} Position
+ * @typedef {import('unist').Point} Point
+ * @typedef {import('hast').Element} Element
+ * @typedef {import('hast').Root} Root
+ * @typedef {import('hast').Content} Content
+ * @typedef {import('parse5').DefaultTreeAdapterMap} DefaultTreeAdapterMap
+ * @typedef {import('parse5').Token.ElementLocation} P5ElementLocation
+ * @typedef {import('parse5').Token.Location} P5Location
+ */
+
+/**
+ * @typedef {Content | Root} Node
+ * @typedef {DefaultTreeAdapterMap['document']} P5Document
+ * @typedef {DefaultTreeAdapterMap['documentFragment']} P5DocumentFragment
+ * @typedef {DefaultTreeAdapterMap['documentType']} P5DocumentType
+ * @typedef {DefaultTreeAdapterMap['commentNode']} P5Comment
+ * @typedef {DefaultTreeAdapterMap['textNode']} P5Text
+ * @typedef {DefaultTreeAdapterMap['element']} P5Element
+ * @typedef {DefaultTreeAdapterMap['node']} P5Node
+ * @typedef {DefaultTreeAdapterMap['template']} P5Template
+ *
+ * @typedef {'html' | 'svg'} Space
+ *   Namespace.
+ *
+ * @typedef Options
+ *   Configuration.
+ * @property {Space | null | undefined} [space='html']
+ *   Which space the document is in.
+ *
+ *   When an `<svg>` element is found in the HTML space, this package already
+ *   automatically switches to and from the SVG space when entering and exiting
+ *   it.
+ * @property {VFile | null | undefined} [file]
+ *   File used to add positional info to nodes.
+ *
+ *   If given, the file should represent the original HTML source.
+ * @property {boolean} [verbose=false]
+ *   Whether to add extra positional info about starting tags, closing tags,
+ *   and attributes to elements.
+ *
+ *   > 👉 **Note**: only used when `file` is given.
+ *
+ * @typedef State
+ *   Info passed around about the current state.
+ * @property {Schema} schema
+ *   Current schema.
+ * @property {VFile | undefined} file
+ *   Corresponding file.
+ * @property {boolean | undefined} verbose
+ *   Add extra positional info.
+ * @property {boolean} location
+ *   Whether location info was found.
+ */
+
+
+
+
+
+
+const hast_util_from_parse5_lib_own = {}.hasOwnProperty
+
+/**
+ * Transform a `parse5` AST to hast.
+ *
+ * @param {P5Node} tree
+ *   `parse5` tree to transform.
+ * @param {Options | VFile | null | undefined} [options]
+ *   Configuration.
+ * @returns {Node}
+ *   hast tree.
+ */
+function fromParse5(tree, options) {
+  const options_ = options || {}
+  /** @type {Options} */
+  let settings
+  /** @type {VFile | undefined} */
+  let file
+
+  if (isFile(options_)) {
+    file = options_
+    settings = {}
+  } else {
+    file = options_.file || undefined
+    settings = options_
+  }
+
+  return lib_one(
+    {
+      schema: settings.space === 'svg' ? property_information_svg : property_information_html,
+      file,
+      verbose: settings.verbose,
+      location: false
+    },
+    tree
+  )
+}
+
+/**
+ * Transform a node.
+ *
+ * @param {State} state
+ *   Info passed around about the current state.
+ * @param {P5Node} node
+ *   p5 node.
+ * @returns {Node}
+ *   hast node.
+ */
+function lib_one(state, node) {
+  /** @type {Node} */
+  let result
+
+  switch (node.nodeName) {
+    case '#comment': {
+      const reference = /** @type {P5Comment} */ (node)
+      result = {type: 'comment', value: reference.data}
+      patch(state, reference, result)
+      return result
+    }
+
+    case '#document':
+    case '#document-fragment': {
+      const reference = /** @type {P5Document | P5DocumentFragment} */ (node)
+      const quirksMode =
+        'mode' in reference
+          ? reference.mode === 'quirks' || reference.mode === 'limited-quirks'
+          : false
+
+      result = {
+        type: 'root',
+        children: hast_util_from_parse5_lib_all(state, node.childNodes),
+        data: {quirksMode}
+      }
+
+      if (state.file && state.location) {
+        const doc = String(state.file)
+        const loc = vfile_location_location(doc)
+        result.position = {start: loc.toPoint(0), end: loc.toPoint(doc.length)}
+      }
+
+      return result
+    }
+
+    case '#documentType': {
+      const reference = /** @type {P5DocumentType} */ (node)
+      // @ts-expect-error Types are out of date.
+      result = {type: 'doctype'}
+      patch(state, reference, result)
+      return result
+    }
+
+    case '#text': {
+      const reference = /** @type {P5Text} */ (node)
+      result = {type: 'text', value: reference.value}
+      patch(state, reference, result)
+      return result
+    }
+
+    // Element.
+    default: {
+      const reference = /** @type {P5Element} */ (node)
+      result = lib_element(state, reference)
+      return result
+    }
+  }
+}
+
+/**
+ * Transform children.
+ *
+ * @param {State} state
+ *   Info passed around about the current state.
+ * @param {Array<P5Node>} nodes
+ *   Nodes.
+ * @returns {Array<Content>}
+ *   hast nodes.
+ */
+function hast_util_from_parse5_lib_all(state, nodes) {
+  let index = -1
+  /** @type {Array<Content>} */
+  const result = []
+
+  while (++index < nodes.length) {
+    // @ts-expect-error Assume no roots in `nodes`.
+    result[index] = lib_one(state, nodes[index])
+  }
+
+  return result
+}
+
+/**
+ * Transform an element.
+ *
+ * @param {State} state
+ *   Info passed around about the current state.
+ * @param {P5Element} node
+ *   `parse5` node to transform.
+ * @returns {Element}
+ *   hast node.
+ */
+function lib_element(state, node) {
+  const schema = state.schema
+
+  state.schema = node.namespaceURI === webNamespaces.svg ? property_information_svg : property_information_html
+
+  // Props.
+  let index = -1
+  /** @type {Record<string, string>} */
+  const props = {}
+
+  while (++index < node.attrs.length) {
+    const attribute = node.attrs[index]
+    props[(attribute.prefix ? attribute.prefix + ':' : '') + attribute.name] =
+      attribute.value
+  }
+
+  // Build.
+  const fn = state.schema.space === 'svg' ? s : h
+  const result = fn(node.tagName, props, hast_util_from_parse5_lib_all(state, node.childNodes))
+  patch(state, node, result)
+
+  // Switch content.
+  if (result.tagName === 'template') {
+    const reference = /** @type {P5Template} */ (node)
+    const pos = reference.sourceCodeLocation
+    const startTag = pos && pos.startTag && lib_position(pos.startTag)
+    const endTag = pos && pos.endTag && lib_position(pos.endTag)
+
+    /** @type {Root} */
+    // @ts-expect-error Types are wrong.
+    const content = lib_one(state, reference.content)
+
+    if (startTag && endTag && state.file) {
+      content.position = {start: startTag.end, end: endTag.start}
+    }
+
+    result.content = content
+  }
+
+  state.schema = schema
+
+  return result
+}
+
+/**
+ * Patch positional info from `from` onto `to`.
+ *
+ * @param {State} state
+ *   Info passed around about the current state.
+ * @param {P5Node} from
+ *   p5 node.
+ * @param {Node} to
+ *   hast node.
+ * @returns {void}
+ *   Nothing.
+ */
+function patch(state, from, to) {
+  if ('sourceCodeLocation' in from && from.sourceCodeLocation && state.file) {
+    const position = createLocation(state, to, from.sourceCodeLocation)
+
+    if (position) {
+      state.location = true
+      to.position = position
+    }
+  }
+}
+
+/**
+ * Create clean positional information.
+ *
+ * @param {State} state
+ *   Info passed around about the current state.
+ * @param {Node} node
+ *   hast node.
+ * @param {P5ElementLocation} location
+ *   p5 location info.
+ * @returns {Position | undefined}
+ *   Position, or nothing.
+ */
+function createLocation(state, node, location) {
+  const result = lib_position(location)
+
+  if (node.type === 'element') {
+    const tail = node.children[node.children.length - 1]
+
+    // Bug for unclosed with children.
+    // See: <https://github.com/inikulin/parse5/issues/109>.
+    if (
+      result &&
+      !location.endTag &&
+      tail &&
+      tail.position &&
+      tail.position.end
+    ) {
+      result.end = Object.assign({}, tail.position.end)
+    }
+
+    if (state.verbose) {
+      /** @type {Record<string, Position | undefined>} */
+      const props = {}
+      /** @type {string} */
+      let key
+
+      if (location.attrs) {
+        for (key in location.attrs) {
+          if (hast_util_from_parse5_lib_own.call(location.attrs, key)) {
+            props[find(state.schema, key).property] = lib_position(
+              location.attrs[key]
+            )
+          }
+        }
+      }
+
+      node.data = {
+        position: {
+          // @ts-expect-error: assume not `undefined`.
+          opening: lib_position(location.startTag),
+          closing: location.endTag ? lib_position(location.endTag) : null,
+          properties: props
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Turn a p5 location into a position.
+ *
+ * @param {P5Location} loc
+ *   Location.
+ * @returns {Position | undefined}
+ *   Position or nothing.
+ */
+function lib_position(loc) {
+  const start = lib_point({
+    line: loc.startLine,
+    column: loc.startCol,
+    offset: loc.startOffset
+  })
+  const end = lib_point({
+    line: loc.endLine,
+    column: loc.endCol,
+    offset: loc.endOffset
+  })
+  // @ts-expect-error `undefined` is fine.
+  return start || end ? {start, end} : undefined
+}
+
+/**
+ * Filter out invalid points.
+ *
+ * @param {Point} point
+ *   Point with potentially `undefined` values.
+ * @returns {Point | undefined}
+ *   Point or nothing.
+ */
+function lib_point(point) {
+  return point.line && point.column ? point : undefined
+}
+
+/**
+ * Check if something is a file.
+ *
+ * @param {VFile | Options} value
+ *   File or options.
+ * @returns {value is VFile}
+ *   Whether `value` is a file.
+ */
+function isFile(value) {
+  return 'messages' in value
+}
+
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/lib/errors.js
+const errors = {
+  abandonedHeadElementChild: {
+    reason: 'Unexpected metadata element after head',
+    description:
+      'Unexpected element after head. Expected the element before `</head>`',
+    url: false
+  },
+  abruptClosingOfEmptyComment: {
+    reason: 'Unexpected abruptly closed empty comment',
+    description: 'Unexpected `>` or `->`. Expected `-->` to close comments'
+  },
+  abruptDoctypePublicIdentifier: {
+    reason: 'Unexpected abruptly closed public identifier',
+    description:
+      'Unexpected `>`. Expected a closing `"` or `\'` after the public identifier'
+  },
+  abruptDoctypeSystemIdentifier: {
+    reason: 'Unexpected abruptly closed system identifier',
+    description:
+      'Unexpected `>`. Expected a closing `"` or `\'` after the identifier identifier'
+  },
+  absenceOfDigitsInNumericCharacterReference: {
+    reason: 'Unexpected non-digit at start of numeric character reference',
+    description:
+      'Unexpected `%c`. Expected `[0-9]` for decimal references or `[0-9a-fA-F]` for hexadecimal references'
+  },
+  cdataInHtmlContent: {
+    reason: 'Unexpected CDATA section in HTML',
+    description:
+      'Unexpected `<![CDATA[` in HTML. Remove it, use a comment, or encode special characters instead'
+  },
+  characterReferenceOutsideUnicodeRange: {
+    reason: 'Unexpected too big numeric character reference',
+    description:
+      'Unexpectedly high character reference. Expected character references to be at most hexadecimal 10ffff (or decimal 1114111)'
+  },
+  closingOfElementWithOpenChildElements: {
+    reason: 'Unexpected closing tag with open child elements',
+    description:
+      'Unexpectedly closing tag. Expected other tags to be closed first',
+    url: false
+  },
+  controlCharacterInInputStream: {
+    reason: 'Unexpected control character',
+    description:
+      'Unexpected control character `%x`. Expected a non-control code point, 0x00, or ASCII whitespace'
+  },
+  controlCharacterReference: {
+    reason: 'Unexpected control character reference',
+    description:
+      'Unexpectedly control character in reference. Expected a non-control code point, 0x00, or ASCII whitespace'
+  },
+  disallowedContentInNoscriptInHead: {
+    reason: 'Disallowed content inside `<noscript>` in `<head>`',
+    description:
+      'Unexpected text character `%c`. Only use text in `<noscript>`s in `<body>`',
+    url: false
+  },
+  duplicateAttribute: {
+    reason: 'Unexpected duplicate attribute',
+    description:
+      'Unexpectedly double attribute. Expected attributes to occur only once'
+  },
+  endTagWithAttributes: {
+    reason: 'Unexpected attribute on closing tag',
+    description: 'Unexpected attribute. Expected `>` instead'
+  },
+  endTagWithTrailingSolidus: {
+    reason: 'Unexpected slash at end of closing tag',
+    description: 'Unexpected `%c-1`. Expected `>` instead'
+  },
+  endTagWithoutMatchingOpenElement: {
+    reason: 'Unexpected unopened end tag',
+    description: 'Unexpected end tag. Expected no end tag or another end tag',
+    url: false
+  },
+  eofBeforeTagName: {
+    reason: 'Unexpected end of file',
+    description: 'Unexpected end of file. Expected tag name instead'
+  },
+  eofInCdata: {
+    reason: 'Unexpected end of file in CDATA',
+    description: 'Unexpected end of file. Expected `]]>` to close the CDATA'
+  },
+  eofInComment: {
+    reason: 'Unexpected end of file in comment',
+    description: 'Unexpected end of file. Expected `-->` to close the comment'
+  },
+  eofInDoctype: {
+    reason: 'Unexpected end of file in doctype',
+    description:
+      'Unexpected end of file. Expected a valid doctype (such as `<!doctype html>`)'
+  },
+  eofInElementThatCanContainOnlyText: {
+    reason: 'Unexpected end of file in element that can only contain text',
+    description: 'Unexpected end of file. Expected text or a closing tag',
+    url: false
+  },
+  eofInScriptHtmlCommentLikeText: {
+    reason: 'Unexpected end of file in comment inside script',
+    description: 'Unexpected end of file. Expected `-->` to close the comment'
+  },
+  eofInTag: {
+    reason: 'Unexpected end of file in tag',
+    description: 'Unexpected end of file. Expected `>` to close the tag'
+  },
+  incorrectlyClosedComment: {
+    reason: 'Incorrectly closed comment',
+    description: 'Unexpected `%c-1`. Expected `-->` to close the comment'
+  },
+  incorrectlyOpenedComment: {
+    reason: 'Incorrectly opened comment',
+    description: 'Unexpected `%c`. Expected `<!--` to open the comment'
+  },
+  invalidCharacterSequenceAfterDoctypeName: {
+    reason: 'Invalid sequence after doctype name',
+    description: 'Unexpected sequence at `%c`. Expected `public` or `system`'
+  },
+  invalidFirstCharacterOfTagName: {
+    reason: 'Invalid first character in tag name',
+    description: 'Unexpected `%c`. Expected an ASCII letter instead'
+  },
+  misplacedDoctype: {
+    reason: 'Misplaced doctype',
+    description: 'Unexpected doctype. Expected doctype before head',
+    url: false
+  },
+  misplacedStartTagForHeadElement: {
+    reason: 'Misplaced `<head>` start tag',
+    description:
+      'Unexpected start tag `<head>`. Expected `<head>` directly after doctype',
+    url: false
+  },
+  missingAttributeValue: {
+    reason: 'Missing attribute value',
+    description:
+      'Unexpected `%c-1`. Expected an attribute value or no `%c-1` instead'
+  },
+  missingDoctype: {
+    reason: 'Missing doctype before other content',
+    description: 'Expected a `<!doctype html>` before anything else',
+    url: false
+  },
+  missingDoctypeName: {
+    reason: 'Missing doctype name',
+    description: 'Unexpected doctype end at `%c`. Expected `html` instead'
+  },
+  missingDoctypePublicIdentifier: {
+    reason: 'Missing public identifier in doctype',
+    description: 'Unexpected `%c`. Expected identifier for `public` instead'
+  },
+  missingDoctypeSystemIdentifier: {
+    reason: 'Missing system identifier in doctype',
+    description:
+      'Unexpected `%c`. Expected identifier for `system` instead (suggested: `"about:legacy-compat"`)'
+  },
+  missingEndTagName: {
+    reason: 'Missing name in end tag',
+    description: 'Unexpected `%c`. Expected an ASCII letter instead'
+  },
+  missingQuoteBeforeDoctypePublicIdentifier: {
+    reason: 'Missing quote before public identifier in doctype',
+    description: 'Unexpected `%c`. Expected `"` or `\'` instead'
+  },
+  missingQuoteBeforeDoctypeSystemIdentifier: {
+    reason: 'Missing quote before system identifier in doctype',
+    description: 'Unexpected `%c`. Expected `"` or `\'` instead'
+  },
+  missingSemicolonAfterCharacterReference: {
+    reason: 'Missing semicolon after character reference',
+    description: 'Unexpected `%c`. Expected `;` instead'
+  },
+  missingWhitespaceAfterDoctypePublicKeyword: {
+    reason: 'Missing whitespace after public identifier in doctype',
+    description: 'Unexpected `%c`. Expected ASCII whitespace instead'
+  },
+  missingWhitespaceAfterDoctypeSystemKeyword: {
+    reason: 'Missing whitespace after system identifier in doctype',
+    description: 'Unexpected `%c`. Expected ASCII whitespace instead'
+  },
+  missingWhitespaceBeforeDoctypeName: {
+    reason: 'Missing whitespace before doctype name',
+    description: 'Unexpected `%c`. Expected ASCII whitespace instead'
+  },
+  missingWhitespaceBetweenAttributes: {
+    reason: 'Missing whitespace between attributes',
+    description: 'Unexpected `%c`. Expected ASCII whitespace instead'
+  },
+  missingWhitespaceBetweenDoctypePublicAndSystemIdentifiers: {
+    reason:
+      'Missing whitespace between public and system identifiers in doctype',
+    description: 'Unexpected `%c`. Expected ASCII whitespace instead'
+  },
+  nestedComment: {
+    reason: 'Unexpected nested comment',
+    description: 'Unexpected `<!--`. Expected `-->`'
+  },
+  nestedNoscriptInHead: {
+    reason: 'Unexpected nested `<noscript>` in `<head>`',
+    description:
+      'Unexpected `<noscript>`. Expected a closing tag or a meta element',
+    url: false
+  },
+  nonConformingDoctype: {
+    reason: 'Unexpected non-conforming doctype declaration',
+    description:
+      'Expected `<!doctype html>` or `<!doctype html system "about:legacy-compat">`',
+    url: false
+  },
+  nonVoidHtmlElementStartTagWithTrailingSolidus: {
+    reason: 'Unexpected trailing slash on start tag of non-void element',
+    description: 'Unexpected `/`. Expected `>` instead'
+  },
+  noncharacterCharacterReference: {
+    reason:
+      'Unexpected noncharacter code point referenced by character reference',
+    description: 'Unexpected code point. Do not use noncharacters in HTML'
+  },
+  noncharacterInInputStream: {
+    reason: 'Unexpected noncharacter character',
+    description: 'Unexpected code point `%x`. Do not use noncharacters in HTML'
+  },
+  nullCharacterReference: {
+    reason: 'Unexpected NULL character referenced by character reference',
+    description: 'Unexpected code point. Do not use NULL characters in HTML'
+  },
+  openElementsLeftAfterEof: {
+    reason: 'Unexpected end of file',
+    description: 'Unexpected end of file. Expected closing tag instead',
+    url: false
+  },
+  surrogateCharacterReference: {
+    reason: 'Unexpected surrogate character referenced by character reference',
+    description:
+      'Unexpected code point. Do not use lone surrogate characters in HTML'
+  },
+  surrogateInInputStream: {
+    reason: 'Unexpected surrogate character',
+    description:
+      'Unexpected code point `%x`. Do not use lone surrogate characters in HTML'
+  },
+  unexpectedCharacterAfterDoctypeSystemIdentifier: {
+    reason: 'Invalid character after system identifier in doctype',
+    description: 'Unexpected character at `%c`. Expected `>`'
+  },
+  unexpectedCharacterInAttributeName: {
+    reason: 'Unexpected character in attribute name',
+    description:
+      'Unexpected `%c`. Expected whitespace, `/`, `>`, `=`, or probably an ASCII letter'
+  },
+  unexpectedCharacterInUnquotedAttributeValue: {
+    reason: 'Unexpected character in unquoted attribute value',
+    description: 'Unexpected `%c`. Quote the attribute value to include it'
+  },
+  unexpectedEqualsSignBeforeAttributeName: {
+    reason: 'Unexpected equals sign before attribute name',
+    description: 'Unexpected `%c`. Add an attribute name before it'
+  },
+  unexpectedNullCharacter: {
+    reason: 'Unexpected NULL character',
+    description:
+      'Unexpected code point `%x`. Do not use NULL characters in HTML'
+  },
+  unexpectedQuestionMarkInsteadOfTagName: {
+    reason: 'Unexpected question mark instead of tag name',
+    description: 'Unexpected `%c`. Expected an ASCII letter instead'
+  },
+  unexpectedSolidusInTag: {
+    reason: 'Unexpected slash in tag',
+    description:
+      'Unexpected `%c-1`. Expected it followed by `>` or in a quoted attribute value'
+  },
+  unknownNamedCharacterReference: {
+    reason: 'Unexpected unknown named character reference',
+    description:
+      'Unexpected character reference. Expected known named character references'
+  }
+}
+
+;// CONCATENATED MODULE: ./node_modules/hast-util-from-html/lib/index.js
+/**
+ * @typedef {import('hast').Root} Root
+ * @typedef {import('vfile').VFileCompatible} VFileCompatible
+ */
+
+/**
+ * @typedef {Pick<import('hast-util-from-parse5').Options, 'space' | 'verbose'>} FromParse5Options
+ *
+ * @typedef {keyof errors} ErrorCode
+ *   Known names of parse errors.
+ * @typedef {0 | 1 | 2 | boolean} ErrorSeverity
+ *   Error severity:
+ *
+ *   * `0` or `false`
+ *     — turn the parse error off
+ *   * `1` or `true`
+ *     — turn the parse error into a warning
+ *   * `2`
+ *     — turn the parse error into an actual error: processing stops.
+ * @typedef {Partial<Record<ErrorCode, ErrorSeverity | null | undefined>>} ErrorFields
+ *   Error configuration.
+ *
+ * @typedef Error
+ *   Error from `parse5`.
+ * @property {string} code
+ * @property {number} startLine
+ * @property {number} startCol
+ * @property {number} startOffset
+ * @property {number} endLine
+ * @property {number} endCol
+ * @property {number} endOffset
+ *
+ * @callback OnError
+ *   Handle errors.
+ * @param {VFileMessage} error
+ *   Message.
+ * @returns {void}
+ *   Nothing.
+ *
+ * @typedef ParseFields
+ * @property {boolean | null | undefined} [fragment=false]
+ *   Specify whether to parse a fragment, instead of a complete document.
+ *
+ *   In document mode, unopened `html`, `head`, and `body` elements are opened
+ *   in just the right places.
+ * @property {OnError | null | undefined} [onerror]
+ *   Call `onerror` with parse errors while parsing.
+ *
+ *   > 👉 **Note**: parse errors are currently being added to HTML.
+ *   > Not all errors emitted by parse5 (or us) are specced yet.
+ *   > Some documentation may still be missing.
+ *
+ *   Specific rules can be turned off by setting them to `false` (or `0`).
+ *   The default, when `emitParseErrors: true`, is `true` (or `1`), and means
+ *   that rules emit as warnings.
+ *   Rules can also be configured with `2`, to turn them into fatal errors.
+ *
+ * @typedef {FromParse5Options & ParseFields & ErrorFields} Options
+ *   Configuration.
+ */
+
+
+
+
+
+
+
+const base = 'https://html.spec.whatwg.org/multipage/parsing.html#parse-error-'
+
+const fatalities = {2: true, 1: false, 0: null}
+
+/**
+ * Turn serialized HTML into a hast tree.
+ *
+ * @param {VFileCompatible} value
+ *   Serialized HTML to parse.
+ * @param {Options | null | undefined} [options={}]
+ *   Configuration (optional).
+ * @returns {Root}
+ *   Tree.
+ */
+function fromHtml(value, options) {
+  const settings = options || {}
+  const warn = settings.onerror || null
+  const file = value instanceof VFile ? value : new VFile(value)
+  const fn = settings.fragment ? parseFragment : dist_parse
+  const doc = String(file)
+  const p5doc = fn(doc, {
+    sourceCodeLocationInfo: true,
+    onParseError: settings.onerror ? onerror : null,
+    scriptingEnabled: false
+  })
+
+  // @ts-expect-error: `parse5` returns document or fragment, which are always
+  // mapped to roots.
+  return fromParse5(p5doc, {
+    file,
+    space: settings.space,
+    verbose: settings.verbose
+  })
+
+  /**
+   * @param {Error} error
+   */
+  function onerror(error) {
+    const code = error.code
+    const name = lib_camelcase(code)
+    const setting = settings[name]
+    const config = setting === undefined || setting === null ? true : setting
+    const level = typeof config === 'number' ? config : config ? 1 : 0
+    const start = {
+      line: error.startLine,
+      column: error.startCol,
+      offset: error.startOffset
+    }
+    const end = {
+      line: error.endLine,
+      column: error.endCol,
+      offset: error.endOffset
+    }
+
+    if (level) {
+      /* c8 ignore next */
+      const info = errors[name] || {reason: '', description: '', url: ''}
+      const message = new VFileMessage(format(info.reason), {start, end})
+
+      if (file.path) {
+        message.name = file.path + ':' + message.name
+        message.file = file.path
+      }
+
+      message.source = 'parse-error'
+      message.ruleId = code
+      message.fatal = fatalities[level]
+      message.note = format(info.description)
+      message.url = 'url' in info && info.url === false ? null : base + code
+      // @ts-expect-error: `onerror` is not passed if `warn` is not set.
+      warn(message)
+    }
+
+    /**
+     * @param {string} value
+     * @returns {string}
+     */
+    function format(value) {
+      return value
+        .replace(
+          /%c(?:([-+])(\d+))?/g,
+          (_, /** @type {string} */ $1, /** @type {string} */ $2) => {
+            const offset =
+              ($2 ? Number.parseInt($2, 10) : 0) * ($1 === '-' ? -1 : 1)
+            const char = doc.charAt(error.startOffset + offset)
+            return char === '`' ? '` ` `' : char
+          }
+        )
+        .replace(
+          /%x/g,
+          () =>
+            '0x' + doc.charCodeAt(error.startOffset).toString(16).toUpperCase()
+        )
+    }
+  }
+}
+
+/**
+ * @param {string} value
+ * @returns {ErrorCode}
+ */
+function lib_camelcase(value) {
+  // @ts-expect-error: fine.
+  return value.replace(/-[a-z]/g, ($0) => $0.charAt(1).toUpperCase())
+}
+
 ;// CONCATENATED MODULE: ./src/handlers/rich-text.js
+
 
 
 /**
  * @param {NotionRichText} richText
+ * @param {{allowHtml: boolean}} options
  * @returns {HastNode}
  */
-function transformRichText(richText) {
+function transformRichText(richText, options = {}) {
   switch (richText.type) {
     case 'text':
       const {
@@ -14357,6 +24931,14 @@ function transformRichText(richText) {
         annotations,
         href,
       } = richText;
+
+      // Option: allow Html inside RichText to render
+      if (options.allowHtml === true) {
+        const { children } = fromHtml(content, { fragment: true });
+        for (let child of children) {
+          if (child.type === 'element') return children;
+        }
+      }
 
       let node = {
         type: 'text',
@@ -14611,7 +25193,7 @@ function table(block, parent) {
                     content,
                   );
                 }
-                return transformRichText(richText);
+                return transformRichText(richText, { allowHtml: true });
               }),
             ),
           ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@notionhq/client": "^2.2.3",
         "dotenv": "^16.0.3",
         "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^1.0.2",
         "hast-util-heading-rank": "^2.1.1",
         "hast-util-to-html": "^8.0.4",
         "lodash-es": "^4.17.21",
@@ -458,6 +459,17 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
@@ -864,6 +876,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-1.0.2.tgz",
+      "integrity": "sha512-LhrTA2gfCbLOGJq2u/asp4kwuG0y6NhWTXiPKP+n0qNukKy7hc10whqqCFfyvIA1Q5U5d0sp9HhNim9gglEH4A==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-from-parse5": "^7.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^5.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/hast-util-from-parse5": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@notionhq/client": "^2.2.3",
     "dotenv": "^16.0.3",
     "github-slugger": "^2.0.0",
+    "hast-util-from-html": "^1.0.2",
     "hast-util-heading-rank": "^2.1.1",
     "hast-util-to-html": "^8.0.4",
     "lodash-es": "^4.17.21",

--- a/src/handlers/rich-text.js
+++ b/src/handlers/rich-text.js
@@ -1,10 +1,12 @@
 import { h } from 'hastscript';
+import { fromHtml } from 'hast-util-from-html';
 
 /**
  * @param {NotionRichText} richText
+ * @param {{allowHtml: boolean}} options
  * @returns {HastNode}
  */
-export function transformRichText(richText) {
+export function transformRichText(richText, options = {}) {
   switch (richText.type) {
     case 'text':
       const {
@@ -12,6 +14,14 @@ export function transformRichText(richText) {
         annotations,
         href,
       } = richText;
+
+      // Option: allow Html inside RichText to render
+      if (options.allowHtml === true) {
+        const { children } = fromHtml(content, { fragment: true });
+        for (let child of children) {
+          if (child.type === 'element') return children;
+        }
+      }
 
       let node = {
         type: 'text',

--- a/src/handlers/table.js
+++ b/src/handlers/table.js
@@ -46,7 +46,7 @@ export function table(block, parent) {
                     content,
                   );
                 }
-                return transformRichText(richText);
+                return transformRichText(richText, { allowHtml: true });
               }),
             ),
           ),


### PR DESCRIPTION
## This PR includes:

- added an option to allow HTML inside rich text
- applied the option on table cells to increase the flexibility of tables in Notion

## Example

<img width="379" alt="image" src="https://github.com/nature-of-code/fetch-notion/assets/6762203/c76c8883-7441-4a26-89c9-64dc89c5df27">

The inline HTML will be kept:

```html
<tr>
  <td>0</td>
  <td>
    <div style="width: 20px; height: 20px; background-color: #7F7F7F; border: 1px solid black;"></div>
  </td>
</tr>
```
