### PR TITLE
Add merging side-by-side figures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "hast-util-from-html": "^1.0.2",
         "hast-util-heading-rank": "^2.1.1",
         "hast-util-to-html": "^8.0.4",
+        "hast-util-to-string": "^2.0.0",
         "lodash-es": "^4.17.21",
         "rehype-format": "^4.0.1"
       },
@@ -1054,6 +1055,18 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "hast-util-from-html": "^1.0.2",
     "hast-util-heading-rank": "^2.1.1",
     "hast-util-to-html": "^8.0.4",
+    "hast-util-to-string": "^2.0.0",
     "lodash-es": "^4.17.21",
     "rehype-format": "^4.0.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import { fromNotion } from './hast-from-notion.js';
 import { importExamples } from './import-examples.js';
 import { importImages } from './import-images.js';
 import { handlePagesInternalLinks } from './internal-links.js';
+import { mergeSideBySideFigures } from './plugins/side-by-side-figures.js';
 
 const formatHast = rehypeFormat();
 
@@ -74,6 +75,9 @@ async function transformPage(page) {
   // Transform Notion content to hast
   const pageTitle = (page.type === 'Chapter' ? 'Chapter ' : '') + page.title;
   const hast = fromNotion(pageContent, pageTitle);
+
+  // Apply post processing plugin
+  mergeSideBySideFigures(hast);
 
   // Format using plugin
   formatHast(hast);

--- a/src/plugins/side-by-side-figures.js
+++ b/src/plugins/side-by-side-figures.js
@@ -1,0 +1,45 @@
+import { h } from 'hastscript';
+import { visit } from 'unist-util-visit';
+import { toString } from 'hast-util-to-string';
+
+export function mergeSideBySideFigures(tree) {
+  visit(tree, { tagName: 'div' }, (node, index, parent) => {
+    if (
+      !node.properties.className ||
+      !node.properties.className.includes('col-list')
+    )
+      return;
+
+    // Check if all the column `div`s contain only one figure element
+    for (let column of node.children) {
+      if (
+        column.children.length !== 1 ||
+        column.children[0].tagName !== 'figure'
+      ) {
+        return;
+      }
+    }
+
+    // join the content and the captions
+    const content = node.children.map((column) => {
+      return h(
+        'div',
+        column.children[0].children.filter((e) => e.tagName !== 'figcaption'),
+      );
+    });
+    const captions = node.children.map((column) => {
+      return toString(
+        column.children[0].children.filter(
+          (e) => e.tagName === 'figcaption',
+        )[0],
+      );
+    });
+
+    const mergedElement = h('figure', [
+      h('div.col-list', content),
+      h('figcaption', captions.join(' ')),
+    ]);
+
+    parent.children[index] = mergedElement;
+  });
+}


### PR DESCRIPTION
This PR includes:

- add post-processing: merge the side-by-side figure's caption to one. Reference: https://github.com/nature-of-code/noc-book-2023/issues/280
- created a `/plugins` folder for storing post-processing script that modify the `hast`.