### PR TITLE
Mark text with underline notation as fill-in-blank in code snippet

### DIFF
--- a/src/handlers/code.js
+++ b/src/handlers/code.js
@@ -8,7 +8,9 @@ export function code(block, parent) {
       class: 'codesplit',
       dataCodeLanguage: block.code.language,
     },
-    block.code.rich_text.map(transformRichText),
+    block.code.rich_text.map((text) =>
+      transformRichText(text, { wrapUnderlineBlank: true }),
+    ),
   );
   parent.children.push(node);
 

--- a/src/handlers/rich-text.js
+++ b/src/handlers/rich-text.js
@@ -3,7 +3,7 @@ import { fromHtml } from 'hast-util-from-html';
 
 /**
  * @param {NotionRichText} richText
- * @param {{allowHtml: boolean}} options
+ * @param {{allowHtml: boolean, wrapUnderlineBlank: boolean}} options
  * @returns {HastNode}
  */
 export function transformRichText(richText, options = {}) {
@@ -38,7 +38,12 @@ export function transformRichText(richText, options = {}) {
         if (annotations.code) {
           node = h('code', [node]);
         }
-        if (annotations.underline) {
+      }
+
+      // Option: wrap underline richText in <span class="blank">
+      // This step adds mark to `fill-in-blank text`
+      if (options.wrapUnderlineBlank === true) {
+        if (annotations && annotations.underline) {
           node = h('span.blank', [node]);
         }
       }

--- a/src/handlers/rich-text.js
+++ b/src/handlers/rich-text.js
@@ -38,6 +38,9 @@ export function transformRichText(richText, options = {}) {
         if (annotations.code) {
           node = h('code', [node]);
         }
+        if (annotations.underline) {
+          node = h('span.blank', [node]);
+        }
       }
 
       if (href) {


### PR DESCRIPTION
This PR adds a transformation of fill-in-blank code.

<img width="664" alt="image" src="https://github.com/nature-of-code/fetch-notion/assets/6762203/35fc7117-0f29-46a8-a24f-f8846d53a999">

Any text inside a code snippet block with a Notion's underline notation will be wrapped in a `<span class="blank"/>` tag. This step marks the fill-in-blank part which will later be processed differently for both PDF and Website build.