### PR TITLE
allow code annotation inside figure caption

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25048,16 +25048,9 @@ function list_list(tagName) {
 
 
 function image_image(block, parent) {
-  const className = block.image.caption
-    .filter(({ annotations }) => annotations.code)
-    .map(({ plain_text }) => plain_text)
-    .join(' ');
+  const { caption } = block.image;
 
-  const caption = block.image.caption.filter(
-    ({ annotations }) => !annotations.code,
-  );
-
-  const node = h('figure', { class: className || null }, [
+  const node = h('figure', [
     h('img', {
       src: block.image[block.image.type].url,
       alt: caption.map(({ plain_text }) => plain_text).join(''),
@@ -25122,17 +25115,8 @@ function transformCallout(block) {
         h('h3', plainTextTitle),
       ]);
 
-    // Web-only content
-    case '🌐':
-      return h('div', { dataType: 'web-only' }, [
-        h('p', block.callout.rich_text.map(transformRichText)),
-      ]);
-
-    // PDF-only content
-    case '📖':
-      return h('div', { dataType: 'pdf-only' }, [
-        h('p', block.callout.rich_text.map(transformRichText)),
-      ]);
+    case '🏷️':
+      return h('div', { class: plainTextTitle }, []);
 
     default:
       console.warn('missing handler for callout:', block.callout.icon.emoji);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node src/main.js",
     "build": "ncc build src/main.js -o dist",
-    "test": "c8 --check-coverage node src/lib/test/index.js"
+    "test": "c8 --check-coverage node src/test/index.js"
   },
   "keywords": [],
   "author": "",

--- a/src/handlers/callout.js
+++ b/src/handlers/callout.js
@@ -50,17 +50,8 @@ function transformCallout(block) {
         h('h3', plainTextTitle),
       ]);
 
-    // Web-only content
-    case '🌐':
-      return h('div', { dataType: 'web-only' }, [
-        h('p', block.callout.rich_text.map(transformRichText)),
-      ]);
-
-    // PDF-only content
-    case '📖':
-      return h('div', { dataType: 'pdf-only' }, [
-        h('p', block.callout.rich_text.map(transformRichText)),
-      ]);
+    case '🏷️':
+      return h('div', { class: plainTextTitle }, []);
 
     default:
       console.warn('missing handler for callout:', block.callout.icon.emoji);

--- a/src/handlers/image.js
+++ b/src/handlers/image.js
@@ -2,19 +2,9 @@ import { h } from 'hastscript';
 import { transformRichText } from './rich-text.js';
 
 export function image(block, parent) {
-  const classNames = [];
-  // get first code annotations before any text
-  for (const text of block.image.caption) {
-    if (!text.annotations.code) {
-      break;
-    }
-    classNames.push(text.plain_text);
-  }
-  const className = classNames.join(' ');
+  const { caption } = block.image;
 
-  const caption = block.image.caption.slice(classNames.length);
-
-  const node = h('figure', { class: className || null }, [
+  const node = h('figure', [
     h('img', {
       src: block.image[block.image.type].url,
       alt: caption.map(({ plain_text }) => plain_text).join(''),

--- a/src/handlers/image.js
+++ b/src/handlers/image.js
@@ -2,14 +2,17 @@ import { h } from 'hastscript';
 import { transformRichText } from './rich-text.js';
 
 export function image(block, parent) {
-  const className = block.image.caption
-    .filter(({ annotations }) => annotations.code)
-    .map(({ plain_text }) => plain_text)
-    .join(' ');
+  const classNames = [];
+  // get first code annotations before any text
+  for (const text of block.image.caption) {
+    if (!text.annotations.code) {
+      break;
+    }
+    classNames.push(text.plain_text);
+  }
+  const className = classNames.join(' ');
 
-  const caption = block.image.caption.filter(
-    ({ annotations }) => !annotations.code,
-  );
+  const caption = block.image.caption.slice(classNames.length);
 
   const node = h('figure', { class: className || null }, [
     h('img', {

--- a/src/test/callout.js
+++ b/src/test/callout.js
@@ -269,3 +269,70 @@ test('Callout: Example', (t) => {
 
   t.end();
 });
+
+test('Callout: Custom class names', (t) => {
+  t.deepEqual(
+    transform([
+      {
+        has_children: true,
+        type: 'callout',
+        children: [
+          {
+            type: 'image',
+            image: {
+              type: 'external',
+              external: {
+                url: 'https://example.com/a.jpg',
+              },
+              caption: [
+                {
+                  type: 'text',
+                  text: {
+                    content: 'hello',
+                    link: null,
+                  },
+                  annotations: {
+                    bold: false,
+                    italic: true,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: 'default',
+                  },
+                  plain_text: 'hello',
+                  href: null,
+                },
+              ],
+            },
+          },
+        ],
+        callout: {
+          rich_text: [
+            {
+              type: 'text',
+              text: {
+                content: 'half-width-right',
+                link: null,
+              },
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: true,
+                color: 'default',
+              },
+              plain_text: 'half-width-right',
+            },
+          ],
+          icon: { type: 'emoji', emoji: '🏷️' },
+          color: 'default',
+        },
+      },
+    ]),
+    '<div class="half-width-right"><figure><img src="https://example.com/a.jpg" alt="hello"><figcaption><em>hello</em></figcaption></figure></div>',
+    'should return a image wrapped inside a div with class name `half-width-right`',
+  );
+
+  t.end();
+});

--- a/src/test/image.js
+++ b/src/test/image.js
@@ -32,7 +32,7 @@ test('Image', (t) => {
             {
               type: 'text',
               text: {
-                content: 'hello',
+                content: 'Figure 1: hello ',
                 link: null,
               },
               annotations: {
@@ -43,14 +43,31 @@ test('Image', (t) => {
                 code: false,
                 color: 'default',
               },
-              plain_text: 'hello',
+              plain_text: 'Figure 1: hello ',
+              href: null,
+            },
+            {
+              type: 'text',
+              text: {
+                content: 'world',
+                link: null,
+              },
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: true,
+                color: 'default',
+              },
+              plain_text: 'world',
               href: null,
             },
           ],
         },
       },
     ]),
-    '<figure class="half-width-right"><img src="https://example.com/a.jpg" alt="hello"><figcaption>hello</figcaption></figure>',
+    '<figure class="half-width-right"><img src="https://example.com/a.jpg" alt="Figure 1: hello world"><figcaption>Figure 1: hello <code>world</code></figcaption></figure>',
     'should return a `.half-width-right` figure with image and caption.',
   );
 

--- a/src/test/image.js
+++ b/src/test/image.js
@@ -15,23 +15,6 @@ test('Image', (t) => {
             {
               type: 'text',
               text: {
-                content: 'half-width-right',
-                link: null,
-              },
-              annotations: {
-                bold: false,
-                italic: false,
-                strikethrough: false,
-                underline: false,
-                code: true,
-                color: 'default',
-              },
-              plain_text: 'half-width-right',
-              href: null,
-            },
-            {
-              type: 'text',
-              text: {
                 content: 'Figure 1: hello ',
                 link: null,
               },
@@ -67,8 +50,8 @@ test('Image', (t) => {
         },
       },
     ]),
-    '<figure class="half-width-right"><img src="https://example.com/a.jpg" alt="Figure 1: hello world"><figcaption>Figure 1: hello <code>world</code></figcaption></figure>',
-    'should return a `.half-width-right` figure with image and caption.',
+    '<figure><img src="https://example.com/a.jpg" alt="Figure 1: hello world"><figcaption>Figure 1: hello <code>world</code></figcaption></figure>',
+    'should return a figure with image and caption.',
   );
 
   t.end();


### PR DESCRIPTION
See: https://github.com/nature-of-code/noc-book-2023/issues/415

Instead of using all code annotations as classnames, changed to only use the first n connected codeblocks, before any text.

(Have not tested, _might_ break for some edge case)