### PR TITLE
Keep the HTML inside captions when side-by-side figures are merged

### DIFF
--- a/src/plugins/side-by-side-figures.js
+++ b/src/plugins/side-by-side-figures.js
@@ -27,17 +27,16 @@ export function mergeSideBySideFigures(tree) {
         column.children[0].children.filter((e) => e.tagName !== 'figcaption'),
       );
     });
-    const captions = node.children.map((column) => {
-      return toString(
-        column.children[0].children.filter(
-          (e) => e.tagName === 'figcaption',
-        )[0],
+    const captions = node.children.reduce((result, column) => {
+      return result.concat(
+        column.children[0].children.filter((e) => e.tagName === 'figcaption')[0]
+          .children,
       );
-    });
+    }, []);
 
     const mergedElement = h('figure', [
       h('div.col-list', content),
-      h('figcaption', captions.join(' ')),
+      h('figcaption', captions),
     ]);
 
     parent.children[index] = mergedElement;


### PR DESCRIPTION
Fix of https://github.com/nature-of-code/noc-book-2023/issues/438

---

before: when a group of side-by-side figures merge, their captions are transformed to plain text.

after: the HTML structure in captions are kept.