### PR TITLE
Support snippet in table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .temp/
 coverage/
 node_modules/
+
+content/

--- a/dist/index.js
+++ b/dist/index.js
@@ -25164,31 +25164,39 @@ function table(block, parent) {
       tableRows.map((row) => {
         return h(
           'tr',
-          row.table_row.cells.map((cell) =>
-            h(
+          row.table_row.cells.map((cell) => {
+            const isSnippet = cell.reduce(
+              (pre, cur) => pre && cur.annotations?.code,
+              true,
+            );
+
+            // If a cell is full of inline code
+            // -> Change it to snippet
+            if (isSnippet) {
+              return h(
+                'td',
+                h(
+                  'pre',
+                  h(
+                    'code',
+                    cell
+                      .map((richText) => {
+                        richText.annotations.code = false;
+                        return richText;
+                      })
+                      .map(transformRichText),
+                  ),
+                ),
+              );
+            }
+
+            return h(
               'td',
               cell.map((richText) => {
-                if (
-                  richText.type === 'text' &&
-                  richText.annotations?.code &&
-                  richText.text.content.indexOf('//{block}') === 0
-                ) {
-                  const content = richText.text.content
-                    .split('//{block}')[1]
-                    .trim();
-                  return h(
-                    'pre',
-                    {
-                      class: 'codesplit',
-                      dataCodeLanguage: 'javascript',
-                    },
-                    content,
-                  );
-                }
                 return transformRichText(richText, { allowHtml: true });
               }),
-            ),
-          ),
+            );
+          }),
         );
       }),
     ),

--- a/src/handlers/table.js
+++ b/src/handlers/table.js
@@ -25,31 +25,39 @@ export function table(block, parent) {
       tableRows.map((row) => {
         return h(
           'tr',
-          row.table_row.cells.map((cell) =>
-            h(
+          row.table_row.cells.map((cell) => {
+            const isSnippet = cell.reduce(
+              (pre, cur) => pre && cur.annotations?.code,
+              true,
+            );
+
+            // If a cell is full of inline code
+            // -> Change it to snippet
+            if (isSnippet) {
+              return h(
+                'td',
+                h(
+                  'pre',
+                  h(
+                    'code',
+                    cell
+                      .map((richText) => {
+                        richText.annotations.code = false;
+                        return richText;
+                      })
+                      .map(transformRichText),
+                  ),
+                ),
+              );
+            }
+
+            return h(
               'td',
               cell.map((richText) => {
-                if (
-                  richText.type === 'text' &&
-                  richText.annotations?.code &&
-                  richText.text.content.indexOf('//{block}') === 0
-                ) {
-                  const content = richText.text.content
-                    .split('//{block}')[1]
-                    .trim();
-                  return h(
-                    'pre',
-                    {
-                      class: 'codesplit',
-                      dataCodeLanguage: 'javascript',
-                    },
-                    content,
-                  );
-                }
                 return transformRichText(richText, { allowHtml: true });
               }),
-            ),
-          ),
+            );
+          }),
         );
       }),
     ),


### PR DESCRIPTION
If a table cell only contains code, transform it to a `<pre>` tag

<img width="725" alt="image" src="https://github.com/nature-of-code/fetch-notion/assets/6762203/ab55267f-7315-464a-ac64-bb2c4ba7b008">

-> to ->

<img width="848" alt="image" src="https://github.com/nature-of-code/fetch-notion/assets/6762203/5916a689-4505-4ff3-922c-44b722cf36ae">
