### PR TITLE
Support custom table head styles for <th/>

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25174,9 +25174,28 @@ function table(block, parent) {
         'thead',
         h(
           'tr',
-          tableHead.table_row.cells.map((cell) =>
-            h('th', cell.map(transformRichText)),
-          ),
+          tableHead.table_row.cells.map((cell) => {
+            const content = [];
+            let inlineStyles = null;
+
+            // Find custom styles in cell, e.g.`[width: 200px;]`
+            for (let richText of cell) {
+              if (richText.annotations.code) {
+                const match = /\[([\s\S]+)\]/.exec(richText.text.content);
+                if (match) {
+                  inlineStyles = match[1];
+                  continue;
+                }
+              }
+              content.push(richText);
+            }
+
+            return h(
+              'th',
+              inlineStyles ? { style: inlineStyles } : {},
+              content.map(transformRichText),
+            );
+          }),
         ),
       ),
     h(

--- a/src/handlers/table.js
+++ b/src/handlers/table.js
@@ -15,9 +15,28 @@ export function table(block, parent) {
         'thead',
         h(
           'tr',
-          tableHead.table_row.cells.map((cell) =>
-            h('th', cell.map(transformRichText)),
-          ),
+          tableHead.table_row.cells.map((cell) => {
+            const content = [];
+            let inlineStyles = null;
+
+            // Find custom styles in cell, e.g.`[width: 200px;]`
+            for (let richText of cell) {
+              if (richText.annotations.code) {
+                const match = /\[([\s\S]+)\]/.exec(richText.text.content);
+                if (match) {
+                  inlineStyles = match[1];
+                  continue;
+                }
+              }
+              content.push(richText);
+            }
+
+            return h(
+              'th',
+              inlineStyles ? { style: inlineStyles } : {},
+              content.map(transformRichText),
+            );
+          }),
         ),
       ),
     h(


### PR DESCRIPTION
![image](https://github.com/nature-of-code/fetch-notion/assets/6762203/1d5da457-8eed-4820-9aa9-a44acb1784fe)

=>

```html
<th style="width: 200px;">Property</th>

```