### PR TITLE
Query pages in pdf-only status but not write in `chapters.json`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13883,10 +13883,20 @@ async function fetchPublishedPages(databaseId) {
     notion.databases.query({
       database_id: databaseId,
       filter: {
-        property: 'Status',
-        select: {
-          equals: 'Published',
-        },
+        or: [
+          {
+            property: 'Status',
+            select: {
+              equals: 'Published',
+            },
+          },
+          {
+            property: 'Status',
+            select: {
+              equals: 'PDF-Only',
+            },
+          },
+        ],
       },
       sorts: [
         {
@@ -13903,6 +13913,7 @@ async function fetchPublishedPages(databaseId) {
     pages.push({
       id: page.id,
       title: stringifyProperty(page.properties['Title']),
+      status: stringifyProperty(page.properties['Status']),
       fileName: stringifyProperty(page.properties['File Name']),
       slug: stringifyProperty(page.properties['Slug']),
       type: stringifyProperty(page.properties['Type']),
@@ -26768,13 +26779,15 @@ async function main() {
 }
 
 async function saveIndex(pageList) {
-  const chapters = pageList.map((page) => {
-    return {
-      title: page.title,
-      src: `./${page.fileName}.html`,
-      slug: page.slug || page.fileName,
-    };
-  });
+  const chapters = pageList
+    .filter((page) => page.status === 'Published')
+    .map((page) => {
+      return {
+        title: page.title,
+        src: `./${page.fileName}.html`,
+        slug: page.slug || page.fileName,
+      };
+    });
 
   await external_node_fs_namespaceObject.promises.writeFile('.temp/chapters.json', JSON.stringify(chapters));
 }

--- a/src/main.js
+++ b/src/main.js
@@ -55,13 +55,15 @@ async function main() {
 }
 
 async function saveIndex(pageList) {
-  const chapters = pageList.map((page) => {
-    return {
-      title: page.title,
-      src: `./${page.fileName}.html`,
-      slug: page.slug || page.fileName,
-    };
-  });
+  const chapters = pageList
+    .filter((page) => page.status === 'Published')
+    .map((page) => {
+      return {
+        title: page.title,
+        src: `./${page.fileName}.html`,
+        slug: page.slug || page.fileName,
+      };
+    });
 
   await fs.writeFile('.temp/chapters.json', JSON.stringify(chapters));
 }

--- a/src/notion-api.js
+++ b/src/notion-api.js
@@ -40,10 +40,20 @@ export async function fetchPublishedPages(databaseId) {
     notion.databases.query({
       database_id: databaseId,
       filter: {
-        property: 'Status',
-        select: {
-          equals: 'Published',
-        },
+        or: [
+          {
+            property: 'Status',
+            select: {
+              equals: 'Published',
+            },
+          },
+          {
+            property: 'Status',
+            select: {
+              equals: 'PDF-Only',
+            },
+          },
+        ],
       },
       sorts: [
         {
@@ -60,6 +70,7 @@ export async function fetchPublishedPages(databaseId) {
     pages.push({
       id: page.id,
       title: stringifyProperty(page.properties['Title']),
+      status: stringifyProperty(page.properties['Status']),
       fileName: stringifyProperty(page.properties['File Name']),
       slug: stringifyProperty(page.properties['Slug']),
       type: stringifyProperty(page.properties['Type']),


### PR DESCRIPTION
<img width="511" alt="image" src="https://github.com/nature-of-code/fetch-notion/assets/6762203/a524f714-d3d4-41f6-a6ef-dad7101feff9">

In a database like this, the first row will be fetched and transformed to HTML but not saved to `chapters.json`, so it won't appear in the web build.