### PR TITLE
Annotate inline code in code comment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25283,19 +25283,47 @@ function table(block, parent) {
 
 
 function code(block, parent) {
+  // annotate inline code
+  const richTexts = parseCodeInRichText(block.code.rich_text);
+
   const node = h(
     'pre',
     {
       class: 'codesplit',
       dataCodeLanguage: block.code.language,
     },
-    block.code.rich_text.map((text) =>
+    richTexts.map((text) =>
       transformRichText(text, { wrapUnderlineBlank: true }),
     ),
   );
   parent.children.push(node);
 
   return null;
+}
+
+function parseCodeInRichText(richTexts) {
+  return richTexts.flatMap((richText) => {
+    if (richText.type !== 'text') {
+      return richText;
+    }
+
+    // find code wrapped in backticks e.g. `const value = 1`
+    return richText.text.content.split(/(`[^`]+`)/).map((content) => {
+      const inlineCodeMatch = /`([^`]+)`/.exec(content);
+      return {
+        ...richText,
+        annotations: {
+          ...richText.annotations,
+          code: !!inlineCodeMatch,
+        },
+        text: {
+          ...richText.text,
+          content: inlineCodeMatch ? inlineCodeMatch[1] : content,
+        },
+        plain_text: inlineCodeMatch ? inlineCodeMatch[1] : content,
+      };
+    });
+  });
 }
 
 ;// CONCATENATED MODULE: ./src/handlers/equation.js

--- a/src/handlers/code.js
+++ b/src/handlers/code.js
@@ -2,17 +2,45 @@ import { h } from 'hastscript';
 import { transformRichText } from './rich-text.js';
 
 export function code(block, parent) {
+  // annotate inline code
+  const richTexts = parseCodeInRichText(block.code.rich_text);
+
   const node = h(
     'pre',
     {
       class: 'codesplit',
       dataCodeLanguage: block.code.language,
     },
-    block.code.rich_text.map((text) =>
+    richTexts.map((text) =>
       transformRichText(text, { wrapUnderlineBlank: true }),
     ),
   );
   parent.children.push(node);
 
   return null;
+}
+
+function parseCodeInRichText(richTexts) {
+  return richTexts.flatMap((richText) => {
+    if (richText.type !== 'text') {
+      return richText;
+    }
+
+    // find code wrapped in backticks e.g. `const value = 1`
+    return richText.text.content.split(/(`[^`]+`)/).map((content) => {
+      const inlineCodeMatch = /`([^`]+)`/.exec(content);
+      return {
+        ...richText,
+        annotations: {
+          ...richText.annotations,
+          code: !!inlineCodeMatch,
+        },
+        text: {
+          ...richText.text,
+          content: inlineCodeMatch ? inlineCodeMatch[1] : content,
+        },
+        plain_text: inlineCodeMatch ? inlineCodeMatch[1] : content,
+      };
+    });
+  });
 }


### PR DESCRIPTION
Implementation of the issue: https://github.com/nature-of-code/noc-book-2023/issues/581

Markdown style inline code in code comment will be transformed to code element as in HTML e.g. from:
```
vector can be accessed via the `mag()` function.
```

to:
```
vector can be accessed via the <code>mag()</code> function.
```