### PR TITLE
Add heading 4

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25838,8 +25838,13 @@ function transformCallout(block) {
         h('h3', plainTextTitle),
       ]);
 
+    // Custom class div
     case '🏷️':
       return h('div', { class: plainTextTitle }, []);
+
+    // Heading 4
+    case '4️⃣':
+      return h('h4', plainTextTitle);
 
     default:
       console.warn('missing handler for callout:', block.callout.icon.emoji);

--- a/src/handlers/callout.js
+++ b/src/handlers/callout.js
@@ -50,8 +50,13 @@ function transformCallout(block) {
         h('h3', plainTextTitle),
       ]);
 
+    // Custom class div
     case '🏷️':
       return h('div', { class: plainTextTitle }, []);
+
+    // Heading 4
+    case '4️⃣':
+      return h('h4', plainTextTitle);
 
     default:
       console.warn('missing handler for callout:', block.callout.icon.emoji);


### PR DESCRIPTION
Since Notion does not support level 4 headings. This PR added a way of supporting heading 4 by using custom callout block with the `4️⃣` emoji.