### PR TITLE
Add support for video-link with bookmark

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -25935,6 +25935,12 @@ function transformCallout(block) {
         ]),
       ];
 
+    // Video
+    case '📽️':
+      return [
+        h('div', { dataType: 'video-link', dataTitle: plainTextTitle }, []),
+      ];
+
     // Custom class div
     case '🏷️':
       return [h('div', { class: plainTextTitle }, [])];
@@ -26160,6 +26166,11 @@ function bookmark(block, parent) {
     ]);
     parent.children.push(node);
   }
+
+  // if the parent is an video link callout
+  // set the parent tag's href property
+  if (parent.properties.dataType === 'video-link')
+    parent.properties.href = block.bookmark.url;
 
   return null;
 }

--- a/src/handlers/bookmark.js
+++ b/src/handlers/bookmark.js
@@ -21,5 +21,10 @@ export function bookmark(block, parent) {
     parent.children.push(node);
   }
 
+  // if the parent is an video link callout
+  // set the parent tag's href property
+  if (parent.properties.dataType === 'video-link')
+    parent.properties.href = block.bookmark.url;
+
   return null;
 }

--- a/src/handlers/callout.js
+++ b/src/handlers/callout.js
@@ -58,6 +58,12 @@ function transformCallout(block) {
         ]),
       ];
 
+    // Video
+    case '📽️':
+      return [
+        h('div', { dataType: 'video-link', dataTitle: plainTextTitle }, []),
+      ];
+
     // Custom class div
     case '🏷️':
       return [h('div', { class: plainTextTitle }, [])];


### PR DESCRIPTION
This pull request transforms the video emoji callout block into a `<div>` element. The URL from the bookmark will be elevated to the `href` attribute of the `<div>`, and the remaining content will be kept.

<img width="734" alt="image" src="https://github.com/nature-of-code/fetch-notion/assets/6762203/0f140dba-3e7a-43c7-9459-945165a04bbc">

=>

```html
<div data-type="video-link" data-title="Video 1.2: Vector Math" href="https://thecodingtrain.com/tracks/the-nature-of-code-2/noc/1-vectors/2-vector-math">
  <figure>
    <img src="images/heading-video/heading-video_1.png" alt="">
    <figcaption></figcaption>
  </figure>
</div>
```