### PR TITLE
Bump node version to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ outputs:
   summary:
     description: 'summary of the transfer'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Update the action to run on Node20 according to:

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/